### PR TITLE
Fix: Enable site.conf

### DIFF
--- a/rz-sbc/rzsbc_yocto.sh
+++ b/rz-sbc/rzsbc_yocto.sh
@@ -232,6 +232,11 @@ function build() {
 
     # New style
     TEMPLATECONF=$PWD/meta-renesas/meta-rzg2l/docs/template/conf/rzpi source poky/oe-init-build-env build
+
+    # Copy overrides file as yocto doesnt copy site.conf.sample
+    cp ../meta-renesas/meta-rzg2l/docs/template/conf/rzpi/site.conf.sample conf/site.conf
+
+    # Initiate build
     MACHINE=rzpi bitbake core-image-qt
 
     echo


### PR DESCRIPTION
Enable site.conf by manually copying it in the script.

This is to support overrides.

The first override is for gstreamer-omx in Renesas-SST/ meta-renesas.
Ref: "Fix: gstreamer1.0-omx package url"