### PR TITLE
Dunfell/rz sbc distro#1

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,12 @@ The build script includes functionality to detect and apply new patches as they 
     ├── jq-linux-amd64
     ├── patches
     │   ├── meta-summit-radio
-    │   │   └── 0001-rzsbc-summit-radio-pre-3.4-support-eSDK-build.patch
+    │   │   ├── 0001-rzsbc-summit-radio-pre-3.4-support-eSDK-build.patch
+    │   │   └── 0002-rzsbc-summit-radio-pre-3.4-enable-usb-bt-support.patch
     │   └── poky
     │       └── 0001-meta-classes-esdk-explicitly-address-the-location-of.patch
     ├── README.md
     └── rzsbc_yocto.sh
 
-4 directories, 7 files
+4 directories, 8 files
 ```

--- a/rz-sbc/README.md
+++ b/rz-sbc/README.md
@@ -10,7 +10,8 @@ This directory holds the automated build scripts that perform the rz yocto repos
 ├── jq-linux-amd64
 ├── patches
 │   ├── meta-summit-radio
-│   │   └── 0001-rzsbc-summit-radio-pre-3.4-support-eSDK-build.patch
+│   │   ├── 0001-rzsbc-summit-radio-pre-3.4-support-eSDK-build.patch
+│   │   └── 0002-rzsbc-summit-radio-pre-3.4-enable-usb-bt-support.patch
 │   └── poky
 │       └── 0001-meta-classes-esdk-explicitly-address-the-location-of.patch
 ├── README.md
@@ -91,7 +92,8 @@ The final output within your yocto build directory will be under `tmp/deploy/ima
 │   │   ├── README.md
 │   │   ├── patches
 │   │   │   ├── 0001-meta-classes-esdk-explicitly-address-the-location-of.patch
-│   │   │   └── 0001-rzsbc-summit-radio-pre-3.4-support-eSDK-build.patch
+│   │   │   ├── 0001-rzsbc-summit-radio-pre-3.4-support-eSDK-build.patch
+│   │   │   └── 0002-rzsbc-summit-radio-pre-3.4-enable-usb-bt-support.patch
 │   │   └── rzsbc_yocto.sh
 │   └── tools
 │       ├── bootloader-flasher

--- a/rz-sbc/README.md
+++ b/rz-sbc/README.md
@@ -17,7 +17,7 @@ This directory holds the automated build scripts that perform the rz yocto repos
 ├── README.md
 ├── rzsbc_yocto.sh
 └── site.conf       /* (optional) */
-3 directories, 6 files
+3 directories, 7 files
 
 ``` 
 

--- a/rz-sbc/git_patch.json
+++ b/rz-sbc/git_patch.json
@@ -12,7 +12,8 @@
 		"branch": "lrd-11.39.0.x",
 		"tag": "",
 		"commit": "",
-		"patches": ["patches/meta-summit-radio/0001-rzsbc-summit-radio-pre-3.4-support-eSDK-build.patch"],
+		"patches": ["patches/meta-summit-radio/0001-rzsbc-summit-radio-pre-3.4-support-eSDK-build.patch",
+					"patches/meta-summit-radio/0002-rzsbc-summit-radio-pre-3.4-enable-usb-bt-support.patch"],
 		"type": "git"
 	},
 	"meta-renesas": {

--- a/rz-sbc/patches/meta-summit-radio/0001-rzsbc-summit-radio-pre-3.4-support-eSDK-build.patch
+++ b/rz-sbc/patches/meta-summit-radio/0001-rzsbc-summit-radio-pre-3.4-support-eSDK-build.patch
@@ -1,7 +1,7 @@
-From 3653542865467a4b30d0ae01eaf2711cfa2bfbd4 Mon Sep 17 00:00:00 2001
+From fa19e75547e7d19f7cef1fc42b13ba8b0bbcceca Mon Sep 17 00:00:00 2001
 From: Vu Dang <vu.dang.te@renesas.com>
 Date: Tue, 27 Aug 2024 22:30:43 +0700
-Subject: [PATCH] rzsbc: summit-radio-pre-3.4: support eSDK build
+Subject: [PATCH 1/2] rzsbc: summit-radio-pre-3.4: support eSDK build
 
 Change include:
 - Include files and its version control file: these include files
@@ -179,5 +179,5 @@ index 3b46021..dea1978 100644
 -require ../radio-stack-lwb-hashes.inc
 +require radio-stack-lwb-hashes.inc
 -- 
-2.25.1
+2.42.0.windows.2
 

--- a/rz-sbc/patches/meta-summit-radio/0001-rzsbc-summit-radio-pre-3.4-support-eSDK-build.patch
+++ b/rz-sbc/patches/meta-summit-radio/0001-rzsbc-summit-radio-pre-3.4-support-eSDK-build.patch
@@ -1,15 +1,16 @@
-From fa19e75547e7d19f7cef1fc42b13ba8b0bbcceca Mon Sep 17 00:00:00 2001
-From: Vu Dang <vu.dang.te@renesas.com>
-Date: Tue, 27 Aug 2024 22:30:43 +0700
+From 7614d0be15ab07e6e84ded9526998ac921737200 Mon Sep 17 00:00:00 2001
+From: Tien Nguyen <tien.nguyen.uh@renesas.com>
+Date: Tue, 5 Nov 2024 07:57:18 +0000
 Subject: [PATCH 1/2] rzsbc: summit-radio-pre-3.4: support eSDK build
 
 Change include:
-- Include files and its version control file: these include files
-need to be copied into the meta-layer as do_populate_sdk_ext task does
-not aware any location out of the layer settings. Also, updated its version
-control file to point to the new location in the meta-layer.
+    - Include files and its version control file: these include files
+      need to be copied into the meta-layer as do_populate_sdk_ext task does
+      not aware any location out of the layer settings.
+    - Update version control files to point to the new file locations within the meta-layer.
 
 Signed-off-by: Vu Dang <vu.dang.te@renesas.com>
+Signed-off-by: Tien Nguyen <tien.nguyen.uh@renesas.com>
 ---
  .../radio-stack-4550-hashes.inc               | 14 ++++++
  .../radio-stack-4550-version.inc              |  2 +-
@@ -43,12 +44,12 @@ index 0000000..37b43cd
 +SRC_URI[ath6k-6004-firmware.md5sum] = "0acaac77e1292aa80b080d215704a8fb"
 +SRC_URI[ath6k-6004-firmware.sha256sum] = "87fc258967493ba6b4950d4344043aa6b306b318941120f7144b90b51548bc11"
 diff --git a/meta-summit-radio-pre-3.4/radio-stack-4550-version.inc b/meta-summit-radio-pre-3.4/radio-stack-4550-version.inc
-index 137ad80..70142eb 100644
+index d152904..7c74dee 100644
 --- a/meta-summit-radio-pre-3.4/radio-stack-4550-version.inc
 +++ b/meta-summit-radio-pre-3.4/radio-stack-4550-version.inc
 @@ -7,4 +7,4 @@ SUMMIT_URI_LOCAL = "file://${TOPDIR}/../release"
  SUMMIT_URI_BASE = "${SUMMIT_URI_LOCAL}"
- SUMMIT_URI_BASE_summit-internal = "https://files.devops.rfpros.com/builds/linux"
+ SUMMIT_URI_BASE_summit-internal = "https://${RFPROS_FILESHARE_AUTH}files.devops.rfpros.com/builds/linux"
  
 -require ../radio-stack-4550-hashes.inc
 +require radio-stack-4550-hashes.inc
@@ -105,12 +106,12 @@ index 0000000..6e1bc50
 +SRC_URI[60-radio-firmware-usb-uart.md5sum] = "45a4ecde0eba9681d608e91fee426c2c"
 +SRC_URI[60-radio-firmware-usb-uart.sha256sum] = "085d68c8e39fb549547afaacb995d758e77aabb7a8451f820178543558cfefb0"
 diff --git a/meta-summit-radio-pre-3.4/radio-stack-60-version.inc b/meta-summit-radio-pre-3.4/radio-stack-60-version.inc
-index 6832844..afab27e 100644
+index 36bd223..a807c70 100644
 --- a/meta-summit-radio-pre-3.4/radio-stack-60-version.inc
 +++ b/meta-summit-radio-pre-3.4/radio-stack-60-version.inc
 @@ -7,4 +7,4 @@ SUMMIT_URI_LOCAL = "file://${TOPDIR}/../release"
  SUMMIT_URI_BASE = "https://github.com/LairdCP/Sterling-60-Release-Packages/releases/download/LRD-REL-${PV}"
- SUMMIT_URI_BASE_summit-internal = "https://files.devops.rfpros.com/builds/linux"
+ SUMMIT_URI_BASE_summit-internal = "https://${RFPROS_FILESHARE_AUTH}files.devops.rfpros.com/builds/linux"
  
 -require ../radio-stack-60-hashes.inc
 +require radio-stack-60-hashes.inc
@@ -169,15 +170,15 @@ index 0000000..f7f3baa
 +SRC_URI[lwb5plus-usb-sa-m2-firmware.md5sum] = "c0e8f682ce5020ec5e082874c841f401"
 +SRC_URI[lwb5plus-usb-sa-m2-firmware.sha256sum] = "48cd311ffc66bd62320a8d1b90e12977e465f1dd4503a70cd263f04695bd1704"
 diff --git a/meta-summit-radio-pre-3.4/radio-stack-lwb-version.inc b/meta-summit-radio-pre-3.4/radio-stack-lwb-version.inc
-index 3b46021..dea1978 100644
+index 666f840..a5ee648 100644
 --- a/meta-summit-radio-pre-3.4/radio-stack-lwb-version.inc
 +++ b/meta-summit-radio-pre-3.4/radio-stack-lwb-version.inc
 @@ -7,4 +7,4 @@ SUMMIT_URI_LOCAL = "file://${TOPDIR}/../release"
  SUMMIT_URI_BASE = "https://github.com/LairdCP/Sterling-LWB-and-LWB5-Release-Packages/releases/download/LRD-REL-${PV}"
- SUMMIT_URI_BASE_summit-internal = "https://files.devops.rfpros.com/builds/linux"
+ SUMMIT_URI_BASE_summit-internal = "https://${RFPROS_FILESHARE_AUTH}files.devops.rfpros.com/builds/linux"
  
 -require ../radio-stack-lwb-hashes.inc
 +require radio-stack-lwb-hashes.inc
 -- 
-2.42.0.windows.2
+2.25.1
 

--- a/rz-sbc/patches/meta-summit-radio/0002-rzsbc-summit-radio-pre-3.4-enable-usb-bt-support.patch
+++ b/rz-sbc/patches/meta-summit-radio/0002-rzsbc-summit-radio-pre-3.4-enable-usb-bt-support.patch
@@ -1,0 +1,70 @@
+From e37d1e7abf988ba6512eecfae42e585f7bcf53c1 Mon Sep 17 00:00:00 2001
+From: Vu Dang <vu.dang.te@renesas.com>
+Date: Tue, 8 Oct 2024 19:00:19 +0700
+Subject: [PATCH 2/2] rzsbc: summit-radio-pre-3.4: enable usb bt support
+
+USB BT support is configured in defconfigs/lwb5p. Change the image feature
+to lwb5p and enable all supported USB BT devices that can be configured.
+
+Signed-off-by: Vu Dang <vu.dang.te@renesas.com>
+---
+ ...-usb-bt-extend-usb-bt-devices-suppor.patch | 25 +++++++++++++++++++
+ .../kernel-module-lwb5p-backports-summit.bb   |  6 +++++
+ 2 files changed, 31 insertions(+)
+ create mode 100644 meta-summit-radio-pre-3.4/recipes-bsp/summit-backports/files/0001-backport-drivers-usb-bt-extend-usb-bt-devices-suppor.patch
+
+diff --git a/meta-summit-radio-pre-3.4/recipes-bsp/summit-backports/files/0001-backport-drivers-usb-bt-extend-usb-bt-devices-suppor.patch b/meta-summit-radio-pre-3.4/recipes-bsp/summit-backports/files/0001-backport-drivers-usb-bt-extend-usb-bt-devices-suppor.patch
+new file mode 100644
+index 0000000..c9d64d7
+--- /dev/null
++++ b/meta-summit-radio-pre-3.4/recipes-bsp/summit-backports/files/0001-backport-drivers-usb-bt-extend-usb-bt-devices-suppor.patch
+@@ -0,0 +1,25 @@
++From 0e7f28f3a3c2520c0e1104c0d28caa9ae495d887 Mon Sep 17 00:00:00 2001
++From: Vu Dang <vu.dang.te@renesas.com>
++Date: Mon, 30 Sep 2024 09:50:27 +0000
++Subject: [PATCH] backport-drivers: usb-bt: extend usb bt devices support
++
++Enable support for Realtek, MediaTek devices.
++
++Signed-off-by: Vu Dang <vu.dang.te@renesas.com>
++---
++ defconfigs/lwb5p | 2 ++
++ 1 file changed, 2 insertions(+)
++
++diff --git a/defconfigs/lwb5p b/defconfigs/lwb5p
++index a597b2e..7e9c137 100644
++--- a/defconfigs/lwb5p
+++++ b/defconfigs/lwb5p
++@@ -14,3 +14,5 @@ CPTCFG_BT_HCIUART=m
++ CPTCFG_BT_HCIUART_BCM=y
++ CPTCFG_BT_HCIBTUSB=m
++ CPTCFG_BT_HCIBTUSB_BCM=y
+++CPTCFG_BT_HCIBTUSB_RTL=y
+++CPTCFG_BT_HCIBTUSB_MTK=y
++-- 
++2.24.4
++
+diff --git a/meta-summit-radio-pre-3.4/recipes-bsp/summit-backports/kernel-module-lwb5p-backports-summit.bb b/meta-summit-radio-pre-3.4/recipes-bsp/summit-backports/kernel-module-lwb5p-backports-summit.bb
+index ec05ebb..97f7294 100644
+--- a/meta-summit-radio-pre-3.4/recipes-bsp/summit-backports/kernel-module-lwb5p-backports-summit.bb
++++ b/meta-summit-radio-pre-3.4/recipes-bsp/summit-backports/kernel-module-lwb5p-backports-summit.bb
+@@ -1,5 +1,7 @@
+ SUMMARY = "Summit Backports for LWB5+"
+ 
++FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
++
+ BACKPORTS_CONFIG = "${@bb.utils.contains('DISTRO_FEATURES','bluetooth','lwb5p','lwb5p_nbt',d)}"
+ 
+ RCONFLICTS_${PN} = " \
+@@ -7,4 +9,8 @@ RCONFLICTS_${PN} = " \
+         kernel-module-lwb-backports-summit \
+         "
+ 
++SRC_URI_append = " \
++        file://0001-backport-drivers-usb-bt-extend-usb-bt-devices-suppor.patch \
++"
++
+ require summit-backports.inc radio-stack-lwb-version.inc
+-- 
+2.42.0.windows.2
+

--- a/rz-sbc/patches/meta-summit-radio/0002-rzsbc-summit-radio-pre-3.4-enable-usb-bt-support.patch
+++ b/rz-sbc/patches/meta-summit-radio/0002-rzsbc-summit-radio-pre-3.4-enable-usb-bt-support.patch
@@ -1,4 +1,4 @@
-From e37d1e7abf988ba6512eecfae42e585f7bcf53c1 Mon Sep 17 00:00:00 2001
+From adbe3c86951290a04aaae7c36de43c467bde7f79 Mon Sep 17 00:00:00 2001
 From: Vu Dang <vu.dang.te@renesas.com>
 Date: Tue, 8 Oct 2024 19:00:19 +0700
 Subject: [PATCH 2/2] rzsbc: summit-radio-pre-3.4: enable usb bt support
@@ -66,5 +66,5 @@ index ec05ebb..97f7294 100644
 +
  require summit-backports.inc radio-stack-lwb-version.inc
 -- 
-2.42.0.windows.2
+2.25.1
 

--- a/rz-sbc/rzsbc_yocto.sh
+++ b/rz-sbc/rzsbc_yocto.sh
@@ -24,6 +24,19 @@ TOP_DIR=`pwd`
 JQ="$TOP_DIR/jq-linux-amd64"
 PATCH_FILE="$TOP_DIR/git_patch.json"
 
+# Target image for the build
+# List of supported images
+#  - core-image-minimal
+#  - core-image-bsp
+#  - core-image-weston
+#  - core-image-qt
+#  - renesas-core-image-cli
+#  - renesas-core-image-weston
+#  - renesas-quickboot-cli
+#  - renesas-quickboot-wayland
+# Default is core-image-qt
+: ${IMAGE:=core-image-qt}
+
 # ------------------------------------------------------------------------------
 
 # -----------------------------Global variable------------------------------------
@@ -39,13 +52,26 @@ guideline() {
 	echo ""
 	echo "========="
 	echo "Build yocto"
-	echo " ./rzsbc_yocto.sh <target_build> <target_dir>"
+	echo "$ IMAGE=<target_image> ./rzsbc_yocto.sh <target_build> <target_dir>"
 	echo "--------------------------"
+	echo " - <target_image>: the target Yocto build image. It can be one from the following list of supported images"
+	echo "     1. core-image-minimal"
+	echo "     2. core-image-bsp"
+	echo "     3. core-image-weston"
+	echo "     4. core-image-qt"
+	echo "     5. renesas-core-image-cli"
+	echo "     6. renesas-core-image-weston"
+	echo "     7. renesas-quickboot-cli"
+	echo "     8. renesas-quickboot-wayland"
+	echo "Note: If IMAGE is not set. The default image is core-image-qt"
 	echo " - <target_build>: the build options. It can be an image build (1) or a SDK build (2) as follows"
 	echo "     1. build"
 	echo "     2. build-sdk"
 	echo " - <target_dir>: the build directory"
 	echo "     If not set <target_dir>: current directory will be selected"
+	echo ""
+	echo "For example: "
+	echo "$ IMAGE=renesas-core-image-cli ./rzsbc_yocto.sh build ~/yocto-build"
 	echo "------------------------------------------------------------"
 }
 
@@ -497,7 +523,7 @@ setup_conf(){
 		echo "Local site.conf file not present in this workspace ($WORKSPACE). Assuming developer default build!"
 		# Copy default template overrides file as yocto doesnt copy site.conf.sample
 		cp ../meta-renesas/meta-rzg2l/docs/template/conf/rzpi/site.conf.sample conf/site.conf
-		echo "This build is a common build for rzsbc. It is not based on any release tag."
+		echo "This build is a common build for rzsbc. It is not based on any release tag. Target image: ${IMAGE}"
 	else
 		# Copy local overrides file to yocto build conf folder
 		cp ${WORKSPACE}/site.conf conf/site.conf
@@ -505,7 +531,7 @@ setup_conf(){
 		site_file="conf/site.conf"
 		revision_value=$(grep '^SRCREV_pn-linux-renesas =' "$site_file" | cut -d '=' -f2)
 		revision_value=$(echo "$revision_value" | sed 's/"//g')
-		echo "This build is based on release tag:$revision_value"
+		echo "This build is based on release tag:$revision_value. Target image: ${IMAGE}"
 	fi
 
 
@@ -555,10 +581,10 @@ build_sdk() {
 	fi
 
 	#Initiate build sdk
-	MACHINE=rzpi bitbake core-image-qt -c populate_sdk_ext
+	MACHINE=rzpi bitbake ${IMAGE} -c populate_sdk_ext
 
 	echo
-	echo "Finished the rz yocto sdk build for RZ SBC board"
+	echo "Finished the rz yocto sdk build for RZ SBC board. Target image: ${IMAGE}"
 	echo "========================================================================"
 
 	deploy_build_assets
@@ -572,10 +598,10 @@ build() {
 	setup_conf
 
 	# Initiate build
-	MACHINE=rzpi bitbake core-image-qt
+	MACHINE=rzpi bitbake ${IMAGE}
 
 	echo
-	echo "Finished the rz yocto build for RZ SBC board"
+	echo "Finished the rz yocto build for RZ SBC board. Target image: ${IMAGE}"
 	echo "========================================================================"
 
 	deploy_build_assets


### PR DESCRIPTION
- Support Generic USB Bluetooth framework
- Add a mechanism to pass core-image target to the build. We can also use this mechanism for distro.
For example: 
    DISTRO=Debian ./rzsbc-yocto.sh