### PR TITLE
styhead/rz-sbc: support to build gst-omx 1.16.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,16 +23,20 @@ The build script includes functionality to detect and apply new patches as they 
 ```
 ├── README.md
 └── rz-sbc
+    ├── files_to_add
+    │   └── meta-rz-features
+    │       ├── 0001-rzg2l-sbc-Bring-compat_alloc_user_space-back.patch
+    │       └── 0004-rzg2l-sbc-Get-interrupt-number.patch
     ├── git_patch.json
     ├── jq-linux-amd64
     ├── patches
-    │   ├── meta-summit-radio
-    │   │   ├── 0001-rzsbc-summit-radio-pre-3.4-support-eSDK-build.patch
-    │   │   └── 0002-rzsbc-summit-radio-pre-3.4-enable-usb-bt-support.patch
-    │   └── poky
-    │       └── 0001-meta-classes-esdk-explicitly-address-the-location-of.patch
+    │   ├── meta-rz-features
+    │   │   └── 0001-support-codec-for-linux-6.10-and-yocto-styhead.patch
+    │   └── meta-summit-radio
+    │       ├── 0001-rz-sbc-meta-summit-radio-Support-build-in-yocto-styh.patch
+    │       └── 0002-rz-sbc-summit-radio-support-eSDK-build.patch
     ├── README.md
     └── rzsbc_yocto.sh
 
-4 directories, 8 files
+6 directories, 10 files
 ```

--- a/rz-sbc/README.md
+++ b/rz-sbc/README.md
@@ -6,17 +6,24 @@ This directory holds the automated build scripts that perform the rz yocto repos
 
 ```
 .
+├── files_to_add
+│   └── meta-rz-features
+│       ├── 0001-rzg2l-sbc-Bring-compat_alloc_user_space-back.patch
+│       └── 0004-rzg2l-sbc-Get-interrupt-number.patch
 ├── git_patch.json
 ├── jq-linux-amd64
 ├── patches
-│   └── meta-summit-radio
-│       └── 0001-rz-sbc-Support-build-in-yocto-styhead-release.patch
+│   ├── meta-rz-features
+│   │   └── 0001-support-codec-for-linux-6.10-and-yocto-styhead.patch
+│   └── meta-summit-radio
+│       ├── 0001-rz-sbc-meta-summit-radio-Support-build-in-yocto-styh.patch
+│       └── 0002-rz-sbc-summit-radio-support-eSDK-build.patch
 ├── README.md
-├── rzsbc_yocto.sh
-└── site.conf       /* (optional) */
-2 directories, 5 files
+├── site.conf       /* (optional) */
+└── rzsbc_yocto.sh
 
-``` 
+5 directories, 10 files
+```
 
 ## Organization:
 
@@ -25,6 +32,7 @@ This directory holds the automated build scripts that perform the rz yocto repos
 | git_patch.json       | contains json keys and repository configuration such as: url, branch, tag, commit, repo type and patch paths to apply.                                          |
 | jq-linux-amd64       | json querry oss binary to perform reads of git_patch.json from shell script.                                                                                    |
 | patches/             | folder containing patches. This should ideally be organized into sub directories named after the json key.                                                      |
+| files_to_add/        | folder containing additional files that need to be added to the meta layer. These files are specified in the add_files field of git_patch.json, which defines their source locations and target destinations.                                                      |
 | rzsbc_yocto.sh       | main build script that performs setup, configure and build operations.                                                                                          |
 | site.conf [optional] | An optional overrride site.conf. If present, this will be used as the override file. If not, the template conf site.conf will be used from meta-renesas layer.  |
 | README.md            | This document. This document provides an overview of the rz-sbc build package. It serves as a guide for users to understand how to set up and execute the Yocto build process, as well as how to manage and utilize the build artifacts and patches.|
@@ -39,7 +47,9 @@ The `git_patch.json` contains the following fields for each repository:
 - url: The URL to clone the repository.
 - branch/tag/commit: Specifies the branch, tag, or commit to check out.
 - patches: Lists the patches that need to be applied to this repository.
+- add_files: Lists of additional files that should be copied into the meta layer, specifying their source and target locations.
 - type: Defines whether the repository is hosted remotely (e.g., "git") or is local (e.g., "local").
+- enable: A flag indicating whether the repository should be cloned and included in the Yocto build process. A value of true enables the repository, while false excludes it.
 
 ### Note
 

--- a/rz-sbc/files_to_add/meta-rz-features/0001-rzg2l-sbc-Bring-compat_alloc_user_space-back.patch
+++ b/rz-sbc/files_to_add/meta-rz-features/0001-rzg2l-sbc-Bring-compat_alloc_user_space-back.patch
@@ -1,0 +1,83 @@
+From d6a110c325247fb6bf9872760f169139abe7b672 Mon Sep 17 00:00:00 2001
+From: Khanh Do Duy <khanh.do.yg@bp.renesas.com>
+Date: Wed, 4 Dec 2024 10:27:59 +0000
+Subject: [PATCH 1/2] rzg2l-sbc: Bring compat_alloc_user_space back
+
+Reintroduces the `compat_alloc_user_space` function, necessary for handling
+32-bit compatibility syscalls. This function is used in the mmngr_drv driver.
+
+Upstream-Status: Pending
+---
+ arch/arm64/include/asm/compat.h |  6 ++++++
+ include/linux/compat.h          |  2 ++
+ kernel/compat.c                 | 21 +++++++++++++++++++++
+ 3 files changed, 29 insertions(+)
+
+diff --git a/arch/arm64/include/asm/compat.h b/arch/arm64/include/asm/compat.h
+index ae904a1ad529..b9e2f6aa7077 100644
+--- a/arch/arm64/include/asm/compat.h
++++ b/arch/arm64/include/asm/compat.h
+@@ -27,6 +27,7 @@ typedef u16		compat_ipc_pid_t;
+ #include <linux/types.h>
+ #include <linux/sched.h>
+ #include <linux/sched/task_stack.h>
++#include <linux/uaccess.h>
+ 
+ #ifdef __AARCH64EB__
+ #define COMPAT_UTS_MACHINE	"armv8b\0\0"
+@@ -98,6 +99,11 @@ static inline int is_compat_thread(struct thread_info *thread)
+ 
+ long compat_arm_syscall(struct pt_regs *regs, int scno);
+ 
++static inline void __user *arch_compat_alloc_user_space(long len)
++{
++	return (void __user *)compat_user_stack_pointer() - len;
++}
++
+ #else /* !CONFIG_COMPAT */
+ 
+ static inline int is_compat_thread(struct thread_info *thread)
+diff --git a/include/linux/compat.h b/include/linux/compat.h
+index 56cebaff0c91..f30e617cc00b 100644
+--- a/include/linux/compat.h
++++ b/include/linux/compat.h
+@@ -541,6 +541,8 @@ extern long compat_arch_ptrace(struct task_struct *child, compat_long_t request,
+ 
+ struct epoll_event;	/* fortunately, this one is fixed-layout */
+ 
++extern void __user *compat_alloc_user_space(unsigned long len);
++
+ int compat_restore_altstack(const compat_stack_t __user *uss);
+ int __compat_save_altstack(compat_stack_t __user *, unsigned long);
+ #define unsafe_compat_save_altstack(uss, sp, label) do { \
+diff --git a/kernel/compat.c b/kernel/compat.c
+index fb50f29d9b36..f9f7a79e07c5 100644
+--- a/kernel/compat.c
++++ b/kernel/compat.c
+@@ -269,3 +269,24 @@ get_compat_sigset(sigset_t *set, const compat_sigset_t __user *compat)
+ 	return 0;
+ }
+ EXPORT_SYMBOL_GPL(get_compat_sigset);
++
++/*
++ * Allocate user-space memory for the duration of a single system call,
++ * in order to marshall parameters inside a compat thunk.
++ */
++void __user *compat_alloc_user_space(unsigned long len)
++{
++	void __user *ptr;
++
++	/* If len would occupy more than half of the entire compat space... */
++	if (unlikely(len > (((compat_uptr_t)~0) >> 1)))
++		return NULL;
++
++	ptr = arch_compat_alloc_user_space(len);
++
++	if (unlikely(!access_ok(ptr, len)))
++		return NULL;
++
++	return ptr;
++}
++EXPORT_SYMBOL_GPL(compat_alloc_user_space);
+-- 
+2.25.1

--- a/rz-sbc/files_to_add/meta-rz-features/0004-rzg2l-sbc-Get-interrupt-number.patch
+++ b/rz-sbc/files_to_add/meta-rz-features/0004-rzg2l-sbc-Get-interrupt-number.patch
@@ -1,0 +1,58 @@
+From 9eb7745482d65a7e3aeb4e24b13ea1be341bbc85 Mon Sep 17 00:00:00 2001
+From: Khanh Do Duy <khanh.do.yg@bp.renesas.com>
+Date: Thu, 12 Dec 2024 10:02:26 +0000
+Subject: [PATCH] rzg2l-sbc: Get interrupt number
+
+Replaces calls to platform_get_resource with platform_get_irq
+to retrieve irq_0 and irq_1 numbers.
+
+Upstream-Status: Pending
+
+Signed-off-by: Khanh Do Duy <khanh.do.yg@bp.renesas.com>
+---
+ src/lkm/uvcs_lkm_uf_io.c | 17 ++++++++++-------
+ 1 file changed, 10 insertions(+), 7 deletions(-)
+
+diff --git a/src/lkm/uvcs_lkm_uf_io.c b/src/lkm/uvcs_lkm_uf_io.c
+index b1a16f1..8b10ddc 100644
+--- a/src/lkm/uvcs_lkm_uf_io.c
++++ b/src/lkm/uvcs_lkm_uf_io.c
+@@ -864,6 +864,7 @@ int uvcs_get_vcp_resource(
+ 	int result = -EFAULT;
+ 	struct resource *res;
+ 	int ch;
++	int itr_num;
+ 
+ 
+ 	if ((pdev == NULL) || (vcpinf == NULL))
+@@ -887,19 +888,19 @@ int uvcs_get_vcp_resource(
+ 	}
+ 	vcpinf->pa_ce = (u64)res->start;
+ 
+-	res = platform_get_resource(pdev, IORESOURCE_IRQ, 0);
+-	if (res == NULL) {
++	itr_num = platform_get_irq(pdev, 0);
++	if (itr_num < 0) {
+ 		dev_err(&pdev->dev, "resource not found (irq_0, %u)\n", iparch);
+ 		goto err_exit_1;
+ 	}
+-	vcpinf->irq_vlc = (int)res->start;
++	vcpinf->irq_vlc = itr_num;
+ 
+-	res = platform_get_resource(pdev, IORESOURCE_IRQ, 1);
+-	if (res == NULL) {
+-		dev_err(&pdev->dev, "resource not found (irq_1, %u)\n", iparch);
++	itr_num = platform_get_irq(pdev, 1);
++	if (itr_num < 0) {
++		dev_err(&pdev->dev, "resource not found (irq_0, %u)\n", iparch);
+ 		goto err_exit_1;
+ 	}
+-	vcpinf->irq_ce = (int)res->start;
++	vcpinf->irq_ce = itr_num;
+ 
+ 	if (of_property_read_u32(pdev->dev.of_node, "renesas,#fcp_ch", &ch) < 0) {
+ 		dev_err(&pdev->dev, "of_property_read_u32() failed #%d, %u\n", __LINE__, iparch);
+
+-- 
+2.25.1
+/irq

--- a/rz-sbc/git_patch.json
+++ b/rz-sbc/git_patch.json
@@ -36,6 +36,15 @@
 		"type": "git",
 		"enable": "false"
 	},
+	"meta-qt6": {
+		"url": "git://code.qt.io/yocto/meta-qt6.git",
+		"branch": "6.9",
+		"tag": "",
+		"commit": "",
+		"patches": [],
+		"type": "git",
+		"enable": "true"
+	},
 	"meta-openembedded": {
 		"url": "https://github.com/openembedded/meta-openembedded",
 		"branch": "styhead",

--- a/rz-sbc/git_patch.json
+++ b/rz-sbc/git_patch.json
@@ -74,7 +74,7 @@
 	},
 	"meta-clang": {
 		"url": "https://github.com/kraj/meta-clang",
-		"branch": "dunfell-clang12",
+		"branch": "styhead",
 		"tag": "",
 		"commit": "",
 		"patches": [],
@@ -83,9 +83,9 @@
 	},
 	"meta-browser": {
 		"url": "https://github.com/OSSystems/meta-browser.git",
-		"branch": "",
+		"branch": "master",
 		"tag": "",
-		"commit": "f2d5539552b54099893a7339cbb2ab46b42ee754",
+		"commit": "",
 		"patches": [],
 		"type": "git",
 		"enable": "false"

--- a/rz-sbc/git_patch.json
+++ b/rz-sbc/git_patch.json
@@ -84,6 +84,16 @@
 	"meta-rz-features": {
 		"patches": ["patches/meta-rz-features/0001-support-codec-for-linux-6.10-and-yocto-styhead.patch"],
 		"type": "local",
+		"add_files": [
+			{
+				"source": "files_to_add/meta-rz-features/0001-rzg2l-sbc-Bring-compat_alloc_user_space-back.patch",
+				"target": "meta-rz-features/meta-rz-codecs/recipes-kernel/linux-yocto/files"
+			},
+			{
+				"source": "files_to_add/meta-rz-features/0004-rzg2l-sbc-Get-interrupt-number.patch",
+				"target": "meta-rz-features/meta-rz-codecs/recipes-kernel/kernel-module-uvcs-drv/files"
+			}
+		],
 		"enable": "true"
 	}
 }

--- a/rz-sbc/patches/meta-rz-features/0001-support-codec-for-linux-6.10-and-yocto-styhead.patch
+++ b/rz-sbc/patches/meta-rz-features/0001-support-codec-for-linux-6.10-and-yocto-styhead.patch
@@ -36,6 +36,28 @@ index 64b029f..222a3c9 100644
 +	commercial_gst-plugins-bad commercial_faad2 commercial_faac \
 +	commercial_gstreamer1.0-libav commercial_ffmpeg commercial_x264 \
 +"
+diff --git a/meta-rz-codecs/include/rzg2l-sbc-modules-common.inc b/meta-rz-codecs/include/rzg2l-sbc-modules-common.inc
+new file mode 100644
+index 0000000..fbbebf5
+--- /dev/null
++++ b/meta-rz-codecs/include/rzg2l-sbc-modules-common.inc
+@@ -0,0 +1,9 @@
++export BUILDDIR = "${STAGING_INCDIR}/.."
++export INCSHARED = "${STAGING_INCDIR}"
++export LIBSHARED = "${STAGING_LIBDIR}"
++export KERNELSRC = "${STAGING_KERNEL_DIR}"
++export CROSS_COMPILE = "${TARGET_PREFIX}"
++export KERNELDIR = "${STAGING_KERNEL_DIR}"
++export LDFLAGS = ""
++export CP = "cp"
++require include/rzg2l-sbc-path-common.inc
+diff --git a/meta-rz-codecs/include/rzg2l-sbc-path-common.inc b/meta-rz-codecs/include/rzg2l-sbc-path-common.inc
+new file mode 100644
+index 0000000..d3dcfff
+--- /dev/null
++++ b/meta-rz-codecs/include/rzg2l-sbc-path-common.inc
+@@ -0,0 +1 @@
++RENESAS_DATADIR ?= "/usr/local"
 diff --git a/meta-rz-codecs/recipes-kernel/kernel-module-uvcs-drv/files/0001-Fixing-build-error-kernel-module-uvcs.patch b/meta-rz-codecs/recipes-kernel/kernel-module-uvcs-drv/files/0001-Fixing-build-error-kernel-module-uvcs.patch
 index da3fe67..76787b4 100644
 --- a/meta-rz-codecs/recipes-kernel/kernel-module-uvcs-drv/files/0001-Fixing-build-error-kernel-module-uvcs.patch
@@ -315,524 +337,135 @@ index 0000000..545d799
 +
 +SRC_URI:append:rzg2l-sbc = " file://0001-rzg2l-sbc-Bring-compat_alloc_user_space-back.patch"
 diff --git a/meta-rz-codecs/recipes-multimedia/gstreamer/gstreamer1.0-omx/0001-Support-Bypass-mode.patch b/meta-rz-codecs/recipes-multimedia/gstreamer/gstreamer1.0-omx/0001-Support-Bypass-mode.patch
-deleted file mode 100644
-index 23f9596..0000000
+index 23f9596..ef934d0 100644
 --- a/meta-rz-codecs/recipes-multimedia/gstreamer/gstreamer1.0-omx/0001-Support-Bypass-mode.patch
-+++ /dev/null
-@@ -1,248 +0,0 @@
--From b02611adff81138dbe29c3d0ee888e74668e4ee9 Mon Sep 17 00:00:00 2001
--From: Nhat Thieu <nhat.thieu.xr@renesas.com>
--Date: Thu, 21 Jul 2022 19:12:59 +0700
--Subject: [PATCH 1/3] Support Bypass mode
++++ b/meta-rz-codecs/recipes-multimedia/gstreamer/gstreamer1.0-omx/0001-Support-Bypass-mode.patch
+@@ -6,7 +6,7 @@ Subject: [PATCH 1/3] Support Bypass mode
+     In Bypass mode, OMX does not generate reconfigure signal.
+     However, gstreamer needs reconfigure signal to allocate output buffer pool.
+     This patch will help gstreamer allocate output buffer pool without reconfigure signal in Bypass mode only.
 -
--    In Bypass mode, OMX does not generate reconfigure signal.
--    However, gstreamer needs reconfigure signal to allocate output buffer pool.
--    This patch will help gstreamer allocate output buffer pool without reconfigure signal in Bypass mode only.
--
--Signed-off-by: Nhat Thieu <nhat.thieu.xr@renesas.com>
-----
-- omx/gstomxvideodec.c | 142 ++++++++++++++++++++++++++++++++++++++++---
-- omx/gstomxvideodec.h |   2 +
-- 2 files changed, 137 insertions(+), 7 deletions(-)
--
--diff --git a/omx/gstomxvideodec.c b/omx/gstomxvideodec.c
--index ec3a1c3..a30e271 100644
----- a/omx/gstomxvideodec.c
--+++ b/omx/gstomxvideodec.c
--@@ -100,7 +100,8 @@ enum
--   PROP_NO_COPY,
--   PROP_NO_REORDER,
--   PROP_LOSSY_COMPRESS,
---  PROP_ENABLE_CROP
--+  PROP_ENABLE_CROP,
--+  PROP_BYPASS
-- };
-- 
-- #define GST_OMX_VIDEO_DEC_INTERNAL_ENTROPY_BUFFERS_DEFAULT (5)
--@@ -136,15 +137,30 @@ gst_omx_video_dec_set_property (GObject * object, guint prop_id,
--       self->use_dmabuf = g_value_get_boolean (value);
--       self->has_set_property = TRUE;
--       break;
--+    case PROP_ENABLE_CROP:
--+      self->enable_crop = g_value_get_boolean (value);
--+      break;
--+#ifdef HAVE_VIDEODEC_EXT
--     case PROP_NO_REORDER:
--       self->no_reorder = g_value_get_boolean (value);
--       break;
--     case PROP_LOSSY_COMPRESS:
--       self->lossy_compress = g_value_get_boolean (value);
--       break;
---    case PROP_ENABLE_CROP:
---      self->enable_crop = g_value_get_boolean (value);
--+    case PROP_BYPASS:
--+      self->bypass = g_value_get_boolean (value);
--+      break;
--+#else
--+    case PROP_NO_REORDER:
--+      GST_WARNING_OBJECT (self, "HAVE_VIDEODEC_EXT not enabled. Couldn't configure property no-reorder (require vendor specific implement).\n");
--+      break;
--+    case PROP_LOSSY_COMPRESS:
--+      GST_WARNING_OBJECT (self, "HAVE_VIDEODEC_EXT not enabled. Couldn't configure property lossy-compress (require vendor specific implement).\n");
--+      break;
--+    case PROP_BYPASS:
--+      GST_WARNING_OBJECT (self, "HAVE_VIDEODEC_EXT not enabled. Couldn't configure property bypass (require vendor specific implement).\n");
--       break;
--+#endif
--     default:
--       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
--       break;
--@@ -178,6 +194,9 @@ gst_omx_video_dec_get_property (GObject * object, guint prop_id,
--     case PROP_ENABLE_CROP:
--       g_value_set_boolean (value, self->enable_crop);
--       break;
--+    case PROP_BYPASS:
--+      g_value_set_boolean (value, self->bypass);
--+      break;
--     default:
--       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
--       break;
--@@ -233,6 +252,12 @@ gst_omx_video_dec_class_init (GstOMXVideoDecClass * klass)
--           "Whether or not to enable cropping if there is cropping information on SPS",
--           FALSE, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS |
--           GST_PARAM_MUTABLE_READY));
--+  g_object_class_install_property (gobject_class, PROP_BYPASS,
--+      g_param_spec_boolean ("bypass",
--+          "Use Bypass function",
--+          "Whether or not to use Bypass mode in OMX",
--+          FALSE, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS |
--+          GST_PARAM_MUTABLE_READY));
-- 
--   element_class->change_state =
--       GST_DEBUG_FUNCPTR (gst_omx_video_dec_change_state);
--@@ -278,6 +303,7 @@ gst_omx_video_dec_init (GstOMXVideoDec * self)
--   self->lossy_compress = FALSE;
--   self->has_set_property = FALSE;
--   self->enable_crop = FALSE;
--+  self->bypass = FALSE;
-- 
--   gst_video_decoder_set_packetized (GST_VIDEO_DECODER (self), TRUE);
--   gst_video_decoder_set_use_default_pad_acceptcaps (GST_VIDEO_DECODER_CAST
--@@ -1630,7 +1656,74 @@ enable_port:
--     goto done;
-- 
-- done:
--+  return err;
--+}
--+
--+/* Allocate and configure output buffers for Bypass mode */
--+static OMX_ERRORTYPE
--+gst_omx_video_dec_configure_bypass (GstOMXVideoDec * self)
--+{
--+  GstOMXPort *port;
--+  OMX_ERRORTYPE err;
--+  GstVideoCodecState *state;
--+  OMX_PARAM_PORTDEFINITIONTYPE port_def;
--+  GstVideoFormat format;
--+  GstOMXVideoDecClass *klass = GST_OMX_VIDEO_DEC_GET_CLASS (self);
--+
--+  port = self->dec_out_port;
--+
--+  /* Update caps */
--+  GST_VIDEO_DECODER_STREAM_LOCK (self);
--+
--+  gst_omx_port_get_port_definition (port, &port_def);
--+  g_assert (port_def.format.video.eCompressionFormat == OMX_VIDEO_CodingUnused);
--+
--+  format =
--+      gst_omx_video_get_format_from_omx (port_def.format.video.eColorFormat);
--+
--+  if (format == GST_VIDEO_FORMAT_UNKNOWN) {
--+    GST_ERROR_OBJECT (self, "Unsupported color format: %d",
--+        port_def.format.video.eColorFormat);
--+    GST_VIDEO_DECODER_STREAM_UNLOCK (self);
--+    err = OMX_ErrorUndefined;
--+    goto done;
--+  }
-- 
--+  GST_DEBUG_OBJECT (self,
--+      "Setting output state: format %s (%d), width %u, height %u",
--+      gst_video_format_to_string (format),
--+      port_def.format.video.eColorFormat,
--+      (guint) port_def.format.video.nFrameWidth,
--+      (guint) port_def.format.video.nFrameHeight);
--+
--+  state = gst_video_decoder_set_output_state (GST_VIDEO_DECODER (self),
--+      format, port_def.format.video.nFrameWidth,
--+      port_def.format.video.nFrameHeight, self->input_state);
--+
--+  if (klass->cdata.hacks & GST_OMX_HACK_DEFAULT_PIXEL_ASPECT_RATIO) {
--+    /* Set pixel-aspect-ratio is 1/1. It means that always keep
--+     * original image when display   */
--+    state->info.par_d = state->info.par_n;
--+  }
--+
--+  if (!gst_video_decoder_negotiate (GST_VIDEO_DECODER (self))) {
--+    gst_video_codec_state_unref (state);
--+    GST_ERROR_OBJECT (self, "Failed to negotiate");
--+    err = OMX_ErrorUndefined;
--+    GST_VIDEO_DECODER_STREAM_UNLOCK (self);
--+    goto done;
--+  }
--+
--+  gst_video_codec_state_unref (state);
--+
--+  GST_VIDEO_DECODER_STREAM_UNLOCK (self);
--+
--+  err = gst_omx_video_dec_allocate_output_buffers (self);
--+  if (err != OMX_ErrorNone) {
--+    goto done;
--+  }
--+
--+done:
--   return err;
-- }
-- 
--@@ -2686,8 +2779,16 @@ gst_omx_video_dec_enable (GstOMXVideoDec * self, GstBuffer * input)
--       /* Need to allocate buffers to reach Idle state */
--       if (!gst_omx_video_dec_allocate_in_buffers (self))
--         return FALSE;
---      if (gst_omx_port_allocate_buffers (self->dec_out_port) != OMX_ErrorNone)
---        return FALSE;
--+
--+      if (self->bypass) {
--+        /* In G2L Bypass mode, allocate output buffers here instead
--+         * of waiting for Event PortSettingChanged */
--+        if (gst_omx_video_dec_configure_bypass(self))
--+          return FALSE;
--+      } else {
--+        if (gst_omx_port_allocate_buffers (self->dec_out_port) != OMX_ErrorNone)
--+          return FALSE;
--+      }
--     }
-- 
--     if (gst_omx_component_get_state (self->dec,
--@@ -2917,6 +3018,27 @@ gst_omx_video_dec_set_format (GstVideoDecoder * decoder,
--     gst_omx_component_set_parameter (self->dec,
--         OMXR_MC_IndexParamVideoLossyCompression, &sLossy);
--   }
--+
--+  if (!needs_disable) {
--+    /* Setting bypass mode (output port) */
--+    OMXR_MC_VIDEO_PARAM_BYPASS_POSTPROCESSINGTYPE sBypass;
--+    GST_OMX_INIT_STRUCT (&sBypass);
--+    sBypass.nPortIndex = self->dec_out_port->index;
--+
--+    if (self->bypass == TRUE)
--+      sBypass.bEnable = OMX_TRUE;
--+    else
--+      sBypass.bEnable = OMX_FALSE;
--+
--+    gst_omx_component_set_parameter (self->dec,
--+        OMXR_MC_IndexParamVideoBypassPostprocessing, &sBypass);
--+    gst_omx_component_get_parameter (self->dec,
--+        OMXR_MC_IndexParamVideoBypassPostprocessing, &sBypass);
--+    if (self->bypass != sBypass.bEnable) {
--+      GST_WARNING_OBJECT (self, "Could not set Bypass mode");
--+      self->bypass = sBypass.bEnable;
--+    }
--+  }
-- #else
--   if (self->no_reorder != FALSE)
--     GST_ERROR_OBJECT (self,
--@@ -2940,8 +3062,14 @@ gst_omx_video_dec_set_format (GstVideoDecoder * decoder,
--       out_port_def.format.video.nStride = 192;
--       out_port_def.format.video.nSliceHeight = 192;
--     } else {
---      out_port_def.format.video.nStride = 128;
---      out_port_def.format.video.nSliceHeight = 128;
--+      if (self->bypass) {
--+        /* In G2L Bypass mode, OMX will not send Event PortSettingChanged
--+         * so application has to set parameters for output port manually */
--+        out_port_def.format.video.nFrameWidth =  info->width;
--+        out_port_def.format.video.nFrameHeight =  info->height;
--+        out_port_def.format.video.nStride = (info->width+127)/128*128;
--+        out_port_def.format.video.nSliceHeight = (info->height+15)/16*16;
--+      }
--     }
-- 
--     if (gst_omx_port_update_port_definition (self->dec_out_port,
--diff --git a/omx/gstomxvideodec.h b/omx/gstomxvideodec.h
--index 06645ee..4c8010f 100644
----- a/omx/gstomxvideodec.h
--+++ b/omx/gstomxvideodec.h
--@@ -121,6 +121,8 @@ struct _GstOMXVideoDec
--   gboolean has_set_property;
--   /* Set TRUE to crop as info of conf_win_left_offset and conf_win_top_offset */
--   gboolean enable_crop;
--+  /* Set TRUE to use Bypass mode in OMX */
--+  gboolean bypass;
-- };
-- 
-- struct _GstOMXVideoDecClass
---- 
--2.25.1
--
++Upstream-Status: Pending
+ Signed-off-by: Nhat Thieu <nhat.thieu.xr@renesas.com>
+ ---
+  omx/gstomxvideodec.c | 142 ++++++++++++++++++++++++++++++++++++++++---
 diff --git a/meta-rz-codecs/recipes-multimedia/gstreamer/gstreamer1.0-omx/0002-Fix-error-Resolution-do-not-match-in-running-case-fi.patch b/meta-rz-codecs/recipes-multimedia/gstreamer/gstreamer1.0-omx/0002-Fix-error-Resolution-do-not-match-in-running-case-fi.patch
-deleted file mode 100644
-index 7ffd368..0000000
+index 7ffd368..6e41501 100644
 --- a/meta-rz-codecs/recipes-multimedia/gstreamer/gstreamer1.0-omx/0002-Fix-error-Resolution-do-not-match-in-running-case-fi.patch
-+++ /dev/null
-@@ -1,71 +0,0 @@
--From ecdeb8231f40361d229bb6799deb3ad72be3ee36 Mon Sep 17 00:00:00 2001
--From: Nhat Thieu <nhat.thieu.xr@renesas.com>
--Date: Thu, 21 Jul 2022 19:17:31 +0700
--Subject: [PATCH 2/3] Fix error Resolution do not match in running case fill
-- buffer
++++ b/meta-rz-codecs/recipes-multimedia/gstreamer/gstreamer1.0-omx/0002-Fix-error-Resolution-do-not-match-in-running-case-fi.patch
+@@ -6,7 +6,7 @@ Subject: [PATCH 2/3] Fix error Resolution do not match in running case fill
+ 
+ This error can happen because port_def is not updated in gst_omx_video_dec_loop before run gst_omx_video_dec_fill_buffer.
+ This patch fixed that error.
 -
--This error can happen because port_def is not updated in gst_omx_video_dec_loop before run gst_omx_video_dec_fill_buffer.
--This patch fixed that error.
--
--Signed-off-by: Nhat Thieu <nhat.thieu.xr@renesas.com>
-----
-- omx/gstomxvideodec.c | 20 ++++++++++----------
-- 1 file changed, 10 insertions(+), 10 deletions(-)
--
--diff --git a/omx/gstomxvideodec.c b/omx/gstomxvideodec.c
--index a30e271..0ff1591 100644
----- a/omx/gstomxvideodec.c
--+++ b/omx/gstomxvideodec.c
--@@ -1930,7 +1930,7 @@ gst_omx_video_dec_loop (GstOMXVideoDec * self)
--   if (!gst_pad_has_current_caps (GST_VIDEO_DECODER_SRC_PAD (self)) ||
--       acq_return == GST_OMX_ACQUIRE_BUFFER_RECONFIGURE) {
--     GstVideoCodecState *state;
---    OMX_PARAM_PORTDEFINITIONTYPE port_def;
--+    OMX_PARAM_PORTDEFINITIONTYPE *port_def = &self->dec_out_port->port_def;
--     GstVideoFormat format;
-- 
--     GST_DEBUG_OBJECT (self, "Port settings have changed, updating caps");
--@@ -1963,17 +1963,17 @@ gst_omx_video_dec_loop (GstOMXVideoDec * self)
--       /* Just update caps */
--       GST_VIDEO_DECODER_STREAM_LOCK (self);
-- 
---      gst_omx_port_get_port_definition (port, &port_def);
---      g_assert (port_def.format.video.eCompressionFormat ==
--+      gst_omx_port_get_port_definition (port, port_def);
--+      g_assert (port_def->format.video.eCompressionFormat ==
--           OMX_VIDEO_CodingUnused);
-- 
--       format =
---          gst_omx_video_get_format_from_omx (port_def.format.video.
--+          gst_omx_video_get_format_from_omx (port_def->format.video.
--           eColorFormat);
-- 
--       if (format == GST_VIDEO_FORMAT_UNKNOWN) {
--         GST_ERROR_OBJECT (self, "Unsupported color format: %d",
---            port_def.format.video.eColorFormat);
--+            port_def->format.video.eColorFormat);
--         if (buf)
--           gst_omx_port_release_buffer (port, buf);
--         GST_VIDEO_DECODER_STREAM_UNLOCK (self);
--@@ -1983,13 +1983,13 @@ gst_omx_video_dec_loop (GstOMXVideoDec * self)
--       GST_DEBUG_OBJECT (self,
--           "Setting output state: format %s (%d), width %u, height %u",
--           gst_video_format_to_string (format),
---          port_def.format.video.eColorFormat,
---          (guint) port_def.format.video.nFrameWidth,
---          (guint) port_def.format.video.nFrameHeight);
--+          port_def->format.video.eColorFormat,
--+          (guint) port_def->format.video.nFrameWidth,
--+          (guint) port_def->format.video.nFrameHeight);
-- 
--       state = gst_video_decoder_set_output_state (GST_VIDEO_DECODER (self),
---          format, port_def.format.video.nFrameWidth,
---          port_def.format.video.nFrameHeight, self->input_state);
--+          format, port_def->format.video.nFrameWidth,
--+          port_def->format.video.nFrameHeight, self->input_state);
-- 
--       /* Take framerate and pixel-aspect-ratio from sinkpad caps */
--       if (klass->cdata.hacks & GST_OMX_HACK_DEFAULT_PIXEL_ASPECT_RATIO) {
---- 
--2.25.1
--
++Upstream-Status: Pending
+ Signed-off-by: Nhat Thieu <nhat.thieu.xr@renesas.com>
+ ---
+  omx/gstomxvideodec.c | 20 ++++++++++----------
 diff --git a/meta-rz-codecs/recipes-multimedia/gstreamer/gstreamer1.0-omx/0003-Add-lossy-compress-option-and-bypass-property.patch b/meta-rz-codecs/recipes-multimedia/gstreamer/gstreamer1.0-omx/0003-Add-lossy-compress-option-and-bypass-property.patch
-deleted file mode 100644
-index 95a89bc..0000000
+index 95a89bc..2986b4f 100644
 --- a/meta-rz-codecs/recipes-multimedia/gstreamer/gstreamer1.0-omx/0003-Add-lossy-compress-option-and-bypass-property.patch
-+++ /dev/null
-@@ -1,91 +0,0 @@
--From 57c38d1e4cbec3c4616b42cf425c4d8cb4ef5336 Mon Sep 17 00:00:00 2001
--From: Nhat Thieu <nhat.thieu.xr@renesas.com>
--Date: Thu, 21 Jul 2022 18:05:30 +0700
--Subject: [PATCH 3/3] Add lossy compress option
++++ b/meta-rz-codecs/recipes-multimedia/gstreamer/gstreamer1.0-omx/0003-Add-lossy-compress-option-and-bypass-property.patch
+@@ -4,7 +4,7 @@ Date: Thu, 21 Jul 2022 18:05:30 +0700
+ Subject: [PATCH 3/3] Add lossy compress option
+ 
+ Lossy compress option: suppporting customer on/off lossy conpress property.
 -
--Lossy compress option: suppporting customer on/off lossy conpress property.
--
--Signed-off-by: Nhat Thieu <nhat.thieu.xr@renesas.com>
-----
-- meson.build          | 12 ++++++++++++
-- meson_options.txt    |  2 ++
-- omx/gstomxvideodec.c |  4 ++++
-- 3 files changed, 18 insertions(+)
--
--diff --git a/meson.build b/meson.build
--index c48c19a..c6ca601 100644
----- a/meson.build
--+++ b/meson.build
--@@ -170,6 +170,11 @@ else
--   omx_inc = include_directories (join_paths ('omx', 'openmax'))
-- endif
-- 
--+lossy_compress = get_option('with_lossy_compress')
++Upstream-Status: Pending
+ Signed-off-by: Nhat Thieu <nhat.thieu.xr@renesas.com>
+ ---
+  meson.build          | 12 ++++++++++++
+@@ -21,7 +21,7 @@ index c48c19a..c6ca601 100644
+  endif
+  
+ +lossy_compress = get_option('with_lossy_compress')
 -+if  lossy_compress == 1
--+   cdata.set('HAVE_LOSSY_COMPRESS', 1)
--+endif
--+
-- default_omx_struct_packing = 0
-- omx_target = get_option ('target')
-- if omx_target == 'generic'
--@@ -239,6 +244,13 @@ elif omx_target == 'rcar'
--     cdata.set ('HAVE_VP8ENC_EXT', 1)
--   endif
-- 
--+  # check OMXR_Extension_vp8e.h
--+  if cc.has_header (
--+    'OMXR_Extension_vdcmn.h',
--+    args : gst_omx_args)
--+    cdata.set ('HAVE_VIDEODEC_EXT', 1)
--+  endif
--+
--   # check OMXR_Extension_aapd.h
--   if cc.has_header (
--       'OMXR_Extension_aapd.h',
--diff --git a/meson_options.txt b/meson_options.txt
--index 0afb142..3716507 100644
----- a/meson_options.txt
--+++ b/meson_options.txt
--@@ -1,5 +1,7 @@
-- option('header_path', type : 'string', value : '',
--     description : 'An extra include directory to find the OpenMax headers')
--+option('with_lossy_compress', type : 'boolean', value : false,
--+    description : 'Whether or not to support lossy compress property')
-- option('target', type : 'combo',
--     choices : ['none', 'generic', 'rpi', 'bellagio', 'tizonia', 'zynqultrascaleplus', 'rcar'], value : 'none',
--     description : 'The OMX platform to target')
--diff --git a/omx/gstomxvideodec.c b/omx/gstomxvideodec.c
--index 0ff1591..b35dfe1 100644
----- a/omx/gstomxvideodec.c
--+++ b/omx/gstomxvideodec.c
--@@ -144,9 +144,11 @@ gst_omx_video_dec_set_property (GObject * object, guint prop_id,
--     case PROP_NO_REORDER:
--       self->no_reorder = g_value_get_boolean (value);
--       break;
--+#ifdef HAVE_LOSSY_COMPRESS
--     case PROP_LOSSY_COMPRESS:
--       self->lossy_compress = g_value_get_boolean (value);
--       break;
--+#endif
--     case PROP_BYPASS:
--       self->bypass = g_value_get_boolean (value);
--       break;
--@@ -3004,6 +3006,7 @@ gst_omx_video_dec_set_format (GstVideoDecoder * decoder,
--         &sReorder);
--   }
-- 
--+#ifdef HAVE_LOSSY_COMPRESS
--   if (!needs_disable) {
--     /* Setting lossy compression mode (output port) */
--     OMXR_MC_VIDEO_PARAM_LOSSY_COMPRESSIONTYPE sLossy;
--@@ -3018,6 +3021,7 @@ gst_omx_video_dec_set_format (GstVideoDecoder * decoder,
--     gst_omx_component_set_parameter (self->dec,
--         OMXR_MC_IndexParamVideoLossyCompression, &sLossy);
--   }
--+#endif
-- 
--   if (!needs_disable) {
--     /* Setting bypass mode (output port) */
---- 
--2.25.1
--
+++if  lossy_compress == true
+ +   cdata.set('HAVE_LOSSY_COMPRESS', 1)
+ +endif
+ +
 diff --git a/meta-rz-codecs/recipes-multimedia/gstreamer/gstreamer1.0-omx/0004-gst-pipeline-cannot-corectly-decode-with-vspmfilter-.patch b/meta-rz-codecs/recipes-multimedia/gstreamer/gstreamer1.0-omx/0004-gst-pipeline-cannot-corectly-decode-with-vspmfilter-.patch
-deleted file mode 100644
-index 71556ac..0000000
+index 71556ac..5a34a97 100644
 --- a/meta-rz-codecs/recipes-multimedia/gstreamer/gstreamer1.0-omx/0004-gst-pipeline-cannot-corectly-decode-with-vspmfilter-.patch
-+++ /dev/null
-@@ -1,58 +0,0 @@
--From 92c7a1700640c87a4220219c916a3117b4cee0fc Mon Sep 17 00:00:00 2001
--From: trungvanle <trung.le.xk@renesas.com>
--Date: Thu, 10 Nov 2022 23:59:50 +0700
--Subject: [PATCH] gst-pipeline cannot corectly decode with vspmfilter and
-- filesink/fakesink
++++ b/meta-rz-codecs/recipes-multimedia/gstreamer/gstreamer1.0-omx/0004-gst-pipeline-cannot-corectly-decode-with-vspmfilter-.patch
+@@ -23,7 +23,7 @@ it causes 2 difference phenomena on RZG2L and RZG2 series:
+ default to ensure that framemap is always being used to map the buffers instead of buffermap
+ in case that framemap is required from downstream. Based on meta information, the buffer is mapped
+ correctly. So the error will be fixed
 -
--The error conditions are that:
--	1. Videosink is fakesink or filesink
--	2. Using vspmfilter in dmabuf-use, or outbuf-alloc mode
--	3. Do not scale
--	4. Output video format has 2 or 3 planes
--
--In above conditions, the API "GST_VIDEO_META_API_TYPE" is not added to query from downstream.
--This means that omxh264dec will not set "GST_BUFFER_POOL_OPTION_VIDEO_META" config to
--buffer pool when allocating output buffers. As a result, the buffers are sent to
--vspmfilter from omxh264dec which maps by buffermap instead of framemap. Hence, if the
--video format has 2 or 3 planes, the mapping will be incorrect. Because of wrong address,
--it causes 2 difference phenomena on RZG2L and RZG2 series:
--	1. RZG2L: Error -412 will be output if use fakesink/filesink
--	2. RZG2 series: Output file will be wrong if use filesink
--
---> Solution: Flag GST_BUFFER_POOL_OPTION_VIDEO_META will be added to the buffer pool as
--default to ensure that framemap is always being used to map the buffers instead of buffermap
--in case that framemap is required from downstream. Based on meta information, the buffer is mapped
--correctly. So the error will be fixed
--
--Signed-off-by: trungvanle <trung.le.xk@renesas.com>
-----
-- omx/gstomxvideodec.c | 13 +++++++++----
-- 1 file changed, 9 insertions(+), 4 deletions(-)
--
--diff --git a/omx/gstomxvideodec.c b/omx/gstomxvideodec.c
--index b35dfe1..08a26fd 100644
----- a/omx/gstomxvideodec.c
--+++ b/omx/gstomxvideodec.c
--@@ -3749,10 +3749,15 @@ gst_omx_video_dec_decide_allocation (GstVideoDecoder * bdec, GstQuery * query)
--   g_assert (pool != NULL);
-- 
--   config = gst_buffer_pool_get_config (pool);
---  if (gst_query_find_allocation_meta (query, GST_VIDEO_META_API_TYPE, NULL)) {
---    gst_buffer_pool_config_add_option (config,
---        GST_BUFFER_POOL_OPTION_VIDEO_META);
---  }
--+
--+  /* The GST_BUFFER_POOL_OPTION_VIDEO_META config must be set 
--+   * to buffer pool in order to always add videometa to buffers and then
--+   * map buffers using frame map. 
--+   *
--+   * Frame map should be used instead of buffer map because it will map the
--+   * buffer correctly based on the meta information.*/
--+  gst_buffer_pool_config_add_option (config,
--+      GST_BUFFER_POOL_OPTION_VIDEO_META);
--   gst_buffer_pool_set_config (pool, config);
--   gst_object_unref (pool);
-- 
---- 
--2.17.1
--
-diff --git a/meta-rz-codecs/recipes-multimedia/gstreamer/gstreamer1.0-omx/gstomx-rzg2l.conf b/meta-rz-codecs/recipes-multimedia/gstreamer/gstreamer1.0-omx/gstomx-rzg2l.conf
-deleted file mode 100644
-index a0cedbe..0000000
---- a/meta-rz-codecs/recipes-multimedia/gstreamer/gstreamer1.0-omx/gstomx-rzg2l.conf
-+++ /dev/null
-@@ -1,21 +0,0 @@
--[omxh264dec]
--type-name=GstOMXH264Dec
--core-name=@RENESAS_DATADIR@/lib/libomxr_core.so
--component-name=OMX.RENESAS.VIDEO.DECODER.H264
--rank=512
--in-port-index=0
--out-port-index=1
--hacks=no-disable-outport;default-pix-aspect-ratio;no-component-reconfigure
--sink-template-caps=video/x-h264,alignment=(string)au,stream-format=(string)byte-stream,width=(int)[1, MAX],height=(int)[1, MAX]
--src-template-caps=video/x-raw,format=(string){NV12,I420},width=(int)[1, MAX],height=(int)[1, MAX]
--
--[omxh264enc]
--type-name=GstOMXH264Enc
--core-name=@RENESAS_DATADIR@/lib/libomxr_core.so
--component-name=OMX.RENESAS.VIDEO.ENCODER.H264
--rank=256
--in-port-index=0
--out-port-index=1
--hacks=no-disable-outport;renesas-encmc-stride-align
--sink-template-caps=video/x-raw,format=(string){NV12,I420},width=(int)[80,3840],height=(int)[80,2160]
--src-template-caps=video/x-h264,stream-format=(string)byte-stream,width=(int)[80,3840],height=(int)[80,2160]
++Upstream-Status: Pending
+ Signed-off-by: trungvanle <trung.le.xk@renesas.com>
+ ---
+  omx/gstomxvideodec.c | 13 +++++++++----
+diff --git a/meta-rz-codecs/recipes-multimedia/gstreamer/gstreamer1.0-omx_1.16.3.bb b/meta-rz-codecs/recipes-multimedia/gstreamer/gstreamer1.0-omx_1.16.3.bb
+new file mode 100644
+index 0000000..67bc70a
+--- /dev/null
++++ b/meta-rz-codecs/recipes-multimedia/gstreamer/gstreamer1.0-omx_1.16.3.bb
+@@ -0,0 +1,63 @@
++SUMMARY = "OpenMAX IL plugins for GStreamer"
++DESCRIPTION = "Wraps available OpenMAX IL components and makes them available as standard GStreamer elements."
++HOMEPAGE = "http://gstreamer.freedesktop.org/"
++SECTION = "multimedia"
++
++LICENSE = "LGPL-2.1-or-later"
++LICENSE_FLAGS = "commercial"
++
++SRC_URI = " \
++    git://github.com/renesas-rcar/gst-omx.git;branch=RCAR-GEN3e/1.16.3;protocol=https \
++    file://0001-Support-Bypass-mode.patch \
++    file://0002-Fix-error-Resolution-do-not-match-in-running-case-fi.patch \
++    file://0003-Add-lossy-compress-option-and-bypass-property.patch \
++    file://0004-gst-pipeline-cannot-corectly-decode-with-vspmfilter-.patch \
++    file://gstomx-rzg2l.conf \
++"
++
++SRCREV = "6db86e9434815d27de853b4c8235d098da5500a2"
++
++DEPENDS = "gstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-bad virtual/libomxil"
++
++inherit meson pkgconfig upstream-version-is-even
++
++LIC_FILES_CHKSUM = " \
++    file://COPYING;md5=4fbd65380cdd255951079008b364516c \
++    file://omx/gstomx.h;beginline=1;endline=22;md5=4b2e62aace379166f9181a8571a14882 \
++"
++
++S = "${WORKDIR}/git"
++
++CONFIGUREOPT_DEPTRACK:append = " --with-omx-target=rcar"
++
++SRCREV_FORMAT = "base_common"
++
++require include/rzg2l-sbc-path-common.inc
++
++DEPENDS += "omx-user-module mmngrbuf-user-module"
++
++GSTREAMER_1_0_OMX_TARGET = "rcar"
++GSTREAMER_1_0_OMX_CORE_NAME = "${libdir}/libomxr_core.so"
++EXTRA_OEMESON += "-Dheader_path=${STAGING_DIR_TARGET}/usr/local/include"
++EXTRA_OEMESON += "-Dtarget=${GSTREAMER_1_0_OMX_TARGET}"
++
++do_configure:prepend() {
++    cd ${S}
++    install -m 0644 ${UNPACKDIR}/gstomx-rzg2l.conf ${S}/config/rcar/gstomx.conf
++    sed -i 's,@RENESAS_DATADIR@,${RENESAS_DATADIR},g' ${S}/config/rcar/gstomx.conf
++    cd ${B}
++}
++
++set_omx_core_name() {
++	sed -i -e "s;^core-name=.*;core-name=${GSTREAMER_1_0_OMX_CORE_NAME};" "${D}${sysconfdir}/xdg/gstomx.conf"
++}
++do_install[postfuncs] += " set_omx_core_name "
++
++FILES:${PN} += "${libdir}/gstreamer-1.0/*.so"
++FILES:${PN}-staticdev += "${libdir}/gstreamer-1.0/*.a"
++
++VIRTUAL-RUNTIME_libomxil ?= "libomxil"
++RDEPENDS:${PN} = "${VIRTUAL-RUNTIME_libomxil}"
++
++RDEPENDS:${PN}:append = " omx-user-module"
++RDEPENDS:${PN}:remove = "libomxil"
 diff --git a/meta-rz-codecs/recipes-multimedia/gstreamer/gstreamer1.0-omx_1.16.3.bbappend b/meta-rz-codecs/recipes-multimedia/gstreamer/gstreamer1.0-omx_1.16.3.bbappend
 deleted file mode 100644
 index 3e3b3e6..0000000
@@ -1497,3 +1130,4 @@ index d8694ad..38d2dfb 100644
 +    gstreamer1.0-plugin-vspmfilter \
 +"
 \ No newline at end of file
+

--- a/rz-sbc/patches/meta-rz-features/0001-support-codec-for-linux-6.10-and-yocto-styhead.patch
+++ b/rz-sbc/patches/meta-rz-features/0001-support-codec-for-linux-6.10-and-yocto-styhead.patch
@@ -94,66 +94,6 @@ index e37e8a0..51ac573 100644
  
  Add SMC calls for uvcs kernel
  
-diff --git a/meta-rz-codecs/recipes-kernel/kernel-module-uvcs-drv/files/0004-rzg2l-sbc-Get-interrupt-number.patch b/meta-rz-codecs/recipes-kernel/kernel-module-uvcs-drv/files/0004-rzg2l-sbc-Get-interrupt-number.patch
-new file mode 100644
-index 0000000..cc4aa10
---- /dev/null
-+++ b/meta-rz-codecs/recipes-kernel/kernel-module-uvcs-drv/files/0004-rzg2l-sbc-Get-interrupt-number.patch
-@@ -0,0 +1,54 @@
-+From 9eb7745482d65a7e3aeb4e24b13ea1be341bbc85 Mon Sep 17 00:00:00 2001
-+From: Khanh Do Duy <khanh.do.yg@bp.renesas.com>
-+Date: Thu, 12 Dec 2024 10:02:26 +0000
-+Subject: [PATCH] rzg2l-sbc: Get interrupt number
-+Upstream-Status: Pending
-+
-+Signed-off-by: Khanh Do Duy <khanh.do.yg@bp.renesas.com>
-+---
-+ src/lkm/uvcs_lkm_uf_io.c | 17 ++++++++++-------
-+ 1 file changed, 10 insertions(+), 7 deletions(-)
-+
-+diff --git a/src/lkm/uvcs_lkm_uf_io.c b/src/lkm/uvcs_lkm_uf_io.c
-+index b1a16f1..8b10ddc 100644
-+--- a/src/lkm/uvcs_lkm_uf_io.c
-++++ b/src/lkm/uvcs_lkm_uf_io.c
-+@@ -864,6 +864,7 @@ int uvcs_get_vcp_resource(
-+ 	int result = -EFAULT;
-+ 	struct resource *res;
-+ 	int ch;
-++	int itr_num;
-+ 
-+ 
-+ 	if ((pdev == NULL) || (vcpinf == NULL))
-+@@ -887,19 +888,19 @@ int uvcs_get_vcp_resource(
-+ 	}
-+ 	vcpinf->pa_ce = (u64)res->start;
-+ 
-+-	res = platform_get_resource(pdev, IORESOURCE_IRQ, 0);
-+-	if (res == NULL) {
-++	itr_num = platform_get_irq(pdev, 0);
-++	if (itr_num < 0) {
-+ 		dev_err(&pdev->dev, "resource not found (irq_0, %u)\n", iparch);
-+ 		goto err_exit_1;
-+ 	}
-+-	vcpinf->irq_vlc = (int)res->start;
-++	vcpinf->irq_vlc = itr_num;
-+ 
-+-	res = platform_get_resource(pdev, IORESOURCE_IRQ, 1);
-+-	if (res == NULL) {
-+-		dev_err(&pdev->dev, "resource not found (irq_1, %u)\n", iparch);
-++	itr_num = platform_get_irq(pdev, 1);
-++	if (itr_num < 0) {
-++		dev_err(&pdev->dev, "resource not found (irq_0, %u)\n", iparch);
-+ 		goto err_exit_1;
-+ 	}
-+-	vcpinf->irq_ce = (int)res->start;
-++	vcpinf->irq_ce = itr_num;
-+ 
-+ 	if (of_property_read_u32(pdev->dev.of_node, "renesas,#fcp_ch", &ch) < 0) {
-+ 		dev_err(&pdev->dev, "of_property_read_u32() failed #%d, %u\n", __LINE__, iparch);
-+
-+-- 
-+2.25.1
-+
 diff --git a/meta-rz-codecs/recipes-kernel/kernel-module-uvcs-drv/kernel-module-uvcs-drv.bb b/meta-rz-codecs/recipes-kernel/kernel-module-uvcs-drv/kernel-module-uvcs-drv.bb
 index 2a1b949..bb9895e 100644
 --- a/meta-rz-codecs/recipes-kernel/kernel-module-uvcs-drv/kernel-module-uvcs-drv.bb
@@ -241,99 +181,13 @@ index 2a1b949..bb9895e 100644
  
 -KERNEL_MODULE_AUTOLOAD = "uvcs_drv"
 +KERNEL_MODULE_AUTOLOAD += "${@oe.utils.conditional('USE_VIDEO_OMX', '1', 'uvcs_drv', '', d)}"
-diff --git a/meta-rz-codecs/recipes-kernel/linux-yocto/file/0001-rzg2l-sbc-Bring-compat_alloc_user_space-back.patch b/meta-rz-codecs/recipes-kernel/linux-yocto/file/0001-rzg2l-sbc-Bring-compat_alloc_user_space-back.patch
-new file mode 100644
-index 0000000..3f17513
---- /dev/null
-+++ b/meta-rz-codecs/recipes-kernel/linux-yocto/file/0001-rzg2l-sbc-Bring-compat_alloc_user_space-back.patch
-@@ -0,0 +1,80 @@
-+From d6a110c325247fb6bf9872760f169139abe7b672 Mon Sep 17 00:00:00 2001
-+From: Khanh Do Duy <khanh.do.yg@bp.renesas.com>
-+Date: Wed, 4 Dec 2024 10:27:59 +0000
-+Subject: [PATCH 1/2] rzg2l-sbc: Bring compat_alloc_user_space back
-+Upstream-Status: Pending
-+---
-+ arch/arm64/include/asm/compat.h |  6 ++++++
-+ include/linux/compat.h          |  2 ++
-+ kernel/compat.c                 | 21 +++++++++++++++++++++
-+ 3 files changed, 29 insertions(+)
-+
-+diff --git a/arch/arm64/include/asm/compat.h b/arch/arm64/include/asm/compat.h
-+index ae904a1ad529..b9e2f6aa7077 100644
-+--- a/arch/arm64/include/asm/compat.h
-++++ b/arch/arm64/include/asm/compat.h
-+@@ -27,6 +27,7 @@ typedef u16		compat_ipc_pid_t;
-+ #include <linux/types.h>
-+ #include <linux/sched.h>
-+ #include <linux/sched/task_stack.h>
-++#include <linux/uaccess.h>
-+ 
-+ #ifdef __AARCH64EB__
-+ #define COMPAT_UTS_MACHINE	"armv8b\0\0"
-+@@ -98,6 +99,11 @@ static inline int is_compat_thread(struct thread_info *thread)
-+ 
-+ long compat_arm_syscall(struct pt_regs *regs, int scno);
-+ 
-++static inline void __user *arch_compat_alloc_user_space(long len)
-++{
-++	return (void __user *)compat_user_stack_pointer() - len;
-++}
-++
-+ #else /* !CONFIG_COMPAT */
-+ 
-+ static inline int is_compat_thread(struct thread_info *thread)
-+diff --git a/include/linux/compat.h b/include/linux/compat.h
-+index 56cebaff0c91..f30e617cc00b 100644
-+--- a/include/linux/compat.h
-++++ b/include/linux/compat.h
-+@@ -541,6 +541,8 @@ extern long compat_arch_ptrace(struct task_struct *child, compat_long_t request,
-+ 
-+ struct epoll_event;	/* fortunately, this one is fixed-layout */
-+ 
-++extern void __user *compat_alloc_user_space(unsigned long len);
-++
-+ int compat_restore_altstack(const compat_stack_t __user *uss);
-+ int __compat_save_altstack(compat_stack_t __user *, unsigned long);
-+ #define unsafe_compat_save_altstack(uss, sp, label) do { \
-+diff --git a/kernel/compat.c b/kernel/compat.c
-+index fb50f29d9b36..f9f7a79e07c5 100644
-+--- a/kernel/compat.c
-++++ b/kernel/compat.c
-+@@ -269,3 +269,24 @@ get_compat_sigset(sigset_t *set, const compat_sigset_t __user *compat)
-+ 	return 0;
-+ }
-+ EXPORT_SYMBOL_GPL(get_compat_sigset);
-++
-++/*
-++ * Allocate user-space memory for the duration of a single system call,
-++ * in order to marshall parameters inside a compat thunk.
-++ */
-++void __user *compat_alloc_user_space(unsigned long len)
-++{
-++	void __user *ptr;
-++
-++	/* If len would occupy more than half of the entire compat space... */
-++	if (unlikely(len > (((compat_uptr_t)~0) >> 1)))
-++		return NULL;
-++
-++	ptr = arch_compat_alloc_user_space(len);
-++
-++	if (unlikely(!access_ok(ptr, len)))
-++		return NULL;
-++
-++	return ptr;
-++}
-++EXPORT_SYMBOL_GPL(compat_alloc_user_space);
-+-- 
-+2.25.1
-+
 diff --git a/meta-rz-codecs/recipes-kernel/linux-yocto/linux-yocto_6.10.bbappend b/meta-rz-codecs/recipes-kernel/linux-yocto/linux-yocto_6.10.bbappend
 new file mode 100644
 index 0000000..545d799
 --- /dev/null
 +++ b/meta-rz-codecs/recipes-kernel/linux-yocto/linux-yocto_6.10.bbappend
 @@ -0,0 +1,3 @@
-+FILESEXTRAPATHS:prepend := "${THISDIR}/file:"
++FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 +
 +SRC_URI:append:rzg2l-sbc = " file://0001-rzg2l-sbc-Bring-compat_alloc_user_space-back.patch"
 diff --git a/meta-rz-codecs/recipes-multimedia/gstreamer/gstreamer1.0-omx/0001-Support-Bypass-mode.patch b/meta-rz-codecs/recipes-multimedia/gstreamer/gstreamer1.0-omx/0001-Support-Bypass-mode.patch
@@ -1130,4 +984,3 @@ index d8694ad..38d2dfb 100644
 +    gstreamer1.0-plugin-vspmfilter \
 +"
 \ No newline at end of file
-

--- a/rz-sbc/rzsbc_yocto.sh
+++ b/rz-sbc/rzsbc_yocto.sh
@@ -83,6 +83,62 @@ clean_repository() {
 	fi
 }
 
+add_files() {
+	local key=$1
+
+	# Get the add_files data from JSON
+	local add_files
+	add_files=$("${JQ}" -r --arg key "$key" '.[$key].add_files' "$PATCH_FILE")
+
+	if [ $? -ne 0 ]; then
+		echo "Error: Failed to parse JSON file for files."
+		exit 1
+	fi
+
+	# Check if add_files is empty or null
+	if [ -z "$add_files" ] || [ "$add_files" == "null" ]; then
+		echo "No files to add for $key (add_files is empty)"
+		return 0
+	fi
+
+	# Check if any of the add_files entries have empty source and target fields
+	invalid_entries=$(echo "$add_files" | grep -E '"source": ""| "target": ""')
+
+	if [ -n "$invalid_entries" ]; then
+		echo "No files to add for $key (invalid source/target entries found)"
+		return 0
+	fi
+
+	echo "Files to add in $key: $add_files"
+
+	# Loop through the add_files list
+	while IFS= read -r file_info; do
+		local source target
+		source=""
+		target=""
+
+		# Extract the source and target from add_files lists
+		source=${TOP_DIR}/$(echo "$file_info" | ${JQ} -r '.source')
+		target=${RZ_TARGET_DIR}/$(echo "$file_info" | ${JQ} -r '.target')
+
+		# Create target folder if it's missing
+		if [ ! -d "$target" ]; then
+			echo "Missing $target, creating directory..."
+			mkdir -p "$target"
+		fi
+
+		echo "Processing: $source -> $target"
+
+		# Check if the source file actually exists before copying
+		if [ -f "$source" ]; then
+			echo "Copying file from $source to $target"
+			cp "$source" "$target"
+		else
+			echo "Source file does not exist: $source"
+		fi
+	done <<< "$("${JQ}" -c '.[]' <<< "$add_files")"
+}
+
 apply_patches() {
 	local key="$1"
 
@@ -259,6 +315,9 @@ bsp_checkout_verification() {
 
 				# Need to apply the necessary patches
 				apply_patches "$bsp_layer"
+
+				# Add addtion files after apply the patches
+				add_files "$bsp_layer"
 			fi
 
 			cd ..
@@ -280,6 +339,10 @@ bsp_checkout_verification() {
 
 				# Need to apply the neccessary patches
 				apply_patches $bsp_layer
+
+				# Add addtion files after apply the patches
+				add_files $bsp_layer
+
 				cd ..
 				continue
 			fi
@@ -300,6 +363,10 @@ bsp_checkout_verification() {
 
 				# Need to apply the neccessary patches
 				apply_patches $bsp_layer
+
+				# Add addtion files after apply the patches
+				add_files $bsp_layer
+
 				cd ..
 				continue
 			fi
@@ -378,6 +445,10 @@ check_and_clone_missing_layers() {
 
 		# Apply necessary patches
 		apply_patches $missing_layer
+
+		# Add addtion files after apply the patches
+		add_files $missing_layer
+
 		cd ..
 	done
 
@@ -492,6 +563,10 @@ get_bsp() {
 
 		# Apply patches
 		apply_patches "$repo_name"
+
+		# Add addtion files after apply the patches
+		add_files "$repo_name"
+
 		cd ..
 	done
 

--- a/rz-sbc/rzsbc_yocto.sh
+++ b/rz-sbc/rzsbc_yocto.sh
@@ -18,7 +18,7 @@ SUFFIX_ZIP=".zip"
 SUFFIX_TAR=".tar.gz"
 
 LSB_ID_OK="Ubuntu"
-LSB_REL_OK="20.04"
+LSB_REL_OK="24.04"
 
 TOP_DIR=`pwd`
 JQ="$TOP_DIR/jq-linux-amd64"
@@ -210,7 +210,7 @@ check_pkg_require(){
 	lsb_rel=`lsb_release -r | cut -f2`
 
 	if [ ${lsb_id} != ${LSB_ID_OK} ] || [ ${lsb_rel} != ${LSB_REL_OK} ]; then
-		echo "Only known working OS is ${LSB_OK}. Kindly ensure this script is run on a supported OS or docker container"
+		echo "Only known working OS is ${LSB_REL_OK}. Kindly ensure this script is run on a supported OS or docker container"
 		exit 0
 	fi
 

--- a/rz-sbc/rzsbc_yocto.sh
+++ b/rz-sbc/rzsbc_yocto.sh
@@ -29,13 +29,12 @@ PATCH_FILE="$TOP_DIR/git_patch.json"
 #  - core-image-minimal
 #  - core-image-bsp
 #  - core-image-weston
-#  - core-image-qt
 #  - renesas-core-image-cli
 #  - renesas-core-image-weston
 #  - renesas-quickboot-cli
 #  - renesas-quickboot-wayland
-# Default is core-image-qt
-: ${IMAGE:=core-image-qt}
+# Default is core-image-weston
+: ${IMAGE:=core-image-weston}
 
 # ------------------------------------------------------------------------------
 
@@ -58,12 +57,11 @@ guideline() {
 	echo "     1. core-image-minimal"
 	echo "     2. core-image-bsp"
 	echo "     3. core-image-weston"
-	echo "     4. core-image-qt"
-	echo "     5. renesas-core-image-cli"
-	echo "     6. renesas-core-image-weston"
-	echo "     7. renesas-quickboot-cli"
-	echo "     8. renesas-quickboot-wayland"
-	echo "Note: If IMAGE is not set. The default image is core-image-qt"
+	echo "     4. renesas-core-image-cli"
+	echo "     5. renesas-core-image-weston"
+	echo "     6. renesas-quickboot-cli"
+	echo "     7. renesas-quickboot-wayland"
+	echo "Note: If IMAGE is not set. The default image is core-image-weston"
 	echo " - <target_build>: the build options. It can be an image build (1) or a SDK build (2) as follows"
 	echo "     1. build"
 	echo "     2. build-sdk"


### PR DESCRIPTION
Currently, we're using OMX 1.18. However, this version does not appear to have been validated on the RZG series.

Therefore, this PR reverts OMX to 1.16 to enable the use of dma-buf.