### PR TITLE
rz-sbc: add ubuntu deploy build function and change target Qt image

### DIFF
--- a/rz-sbc/rzsbc_yocto.sh
+++ b/rz-sbc/rzsbc_yocto.sh
@@ -655,11 +655,12 @@ build() {
 	fi
 
 	deploy_build_assets
+	deploy_ubuntu_build_assets
 	#output
 }
 
 deploy_build_assets() {
-	local target_dir="${RZ_TARGET_DIR}/build/tmp/deploy/images/rzpi/host/src"
+	local target_dir="${RZ_TARGET_DIR}/build/tmp/deploy/images/rzpi/host/src/yocto"
 
 	# Check if the src directory already exists
 	if [ ! -d ${target_dir} ];then
@@ -675,6 +676,23 @@ deploy_build_assets() {
 		cp "${TOP_DIR}/site.conf" "$target_dir"
 	fi
 	cp "${TOP_DIR}/README.md" "$target_dir"
+}
+
+deploy_ubuntu_build_assets() {
+        local target_dir="${RZ_TARGET_DIR}/build/tmp/deploy/images/rzpi/host/src/ubuntu"
+
+        # Check if the src directory already exists
+        if [ ! -d ${target_dir} ];then
+                mkdir -p ${target_dir}
+        fi
+
+        # Copy build assets to the src directory
+        cp -r "${TOP_DIR}/../ubuntu/config" "$target_dir"
+        cp -r "${TOP_DIR}/../ubuntu/docs" "$target_dir"
+        cp -r "${TOP_DIR}/../ubuntu/include" "$target_dir"
+        cp -r "${TOP_DIR}/../ubuntu/script" "$target_dir"
+        cp "${TOP_DIR}/../ubuntu/config.ini" "$target_dir"
+        cp "${TOP_DIR}/../ubuntu/rzsbc_ubuntu.sh" "$target_dir"
 }
 
 # Main output

--- a/ubuntu/config.ini
+++ b/ubuntu/config.ini
@@ -11,7 +11,7 @@ BIN_PATH="./rootfs/usr/bin"
 SCRIPT_PATH="./script"
 
 # Define the core-image-qt (LXDE only)
-core_image_qt_name="core-image-qt-rzpi.tar.bz2"
+core_image_qt_name="renesas-ubuntu-rzpi.tar.bz2"
 
 # Define bluetooth firmware link (LXDE only)
 bluetooth_firmware_link="https://raw.githubusercontent.com/Realtek-OpenSource/android_hardware_realtek/rtk1395/bt/rtkbt/Firmware/BT/rtl8761b_fw"


### PR DESCRIPTION
Changes include:
	- Add a function to deploys the necessary Ubuntu build files to the target directory
	- Change target QT image to renesas-ubuntu