### PR TITLE
rz-cmn-srp: Support common V4L2 initialization script

### DIFF
--- a/rz-cmn-srp/ubuntu/config/ubuntu_lxde/v4l2-init.sh
+++ b/rz-cmn-srp/ubuntu/config/ubuntu_lxde/v4l2-init.sh
@@ -1,11 +1,30 @@
-#!/bin/sh
+#!/bin/bash
+
 ##############################################################################
-# This script is used to setup the camera ov5640 configuration.
+# This script is used to setup the camera ov564x configuration.
 # The script uses the media-ctl tool to setup the camera configuration.
-# The resolution is set to 1920x1080 with UYVY8_1X16 format.
+# ov5640: The resolution is set to 1280x720 with UYVY8_1X16 format.
+# ov5645: The resolution is set to 1280x960 with UYVY8_1X16 format.
 ##############################################################################
-media-ctl -d /dev/media0 -V "'csi-10830400.csi2':1 [fmt:UYVY8_1X16/1280x720 field:none]"
-media-ctl -d /dev/media0 -V "'ov5640 1-003c':0 [fmt:UYVY8_1X16/1280x720 field:none]"
-media-ctl -d /dev/media0 -V "'cru-ip-10830000.video':0 [fmt:UYVY8_1X16/1280x720 field:none]"
-media-ctl -d /dev/media0 -V "'cru-ip-10830000.video':1 [fmt:UYVY8_1X16/1280x720 field:none]"
-v4l2-ctl --set-fmt-video=width=1280,height=720,pixelformat=UYVY
+
+cru=$(cat /sys/class/video4linux/v4l-subdev*/name | grep "cru-ip")
+csi2=$(cat /sys/class/video4linux/v4l-subdev*/name | grep "csi2")
+ov=$(cat /sys/class/video4linux/v4l-subdev*/name | grep "ov")
+default_camera=$(echo "$ov" | awk '{print $1}')
+
+declare -A camera_default_resolution
+camera_default_resolution["ov5640"]="1280x720"
+camera_default_resolution["ov5645"]="1280x960"
+
+# Check for no input
+ov564x_res="${camera_default_resolution[$default_camera]}"
+
+media-ctl -d /dev/media0 -V "'$csi2':0 [fmt:UYVY8_1X16/$ov564x_res field:none]"
+media-ctl -d /dev/media0 -V "'$csi2':1 [fmt:UYVY8_1X16/$ov564x_res field:none]"
+media-ctl -d /dev/media0 -V "'$ov':0 [fmt:UYVY8_1X16/$ov564x_res field:none]"
+media-ctl -d /dev/media0 -V "'$cru':0 [fmt:UYVY8_1X16/$ov564x_res field:none]"
+media-ctl -d /dev/media0 -V "'$cru':1 [fmt:UYVY8_1X16/$ov564x_res field:none]"
+
+width=${ov564x_res%x*}
+height=${ov564x_res#*x}
+v4l2-ctl -d /dev/video0 --set-fmt-video=width=${width},height=${height},pixelformat=UYVY


### PR DESCRIPTION
Change includes:
- Add support for the ov5645 camera sensor
- Support for 1280x960 resolution for the RZG2L-EVK, RZV2L-EVK and RZV2H-EVK
- Support common camera initialization script for all devices