### PR TITLE
rz-cmn: support build scripts for RZV2H-RDK

### DIFF
--- a/rz-cmn-srp/git_patch.json
+++ b/rz-cmn-srp/git_patch.json
@@ -20,7 +20,7 @@
 	},
 	"meta-renesas": {
 		"url": "https://github.com/Renesas-SST/meta-renesas.git",
-		"branch": "styhead/rz-cmn",
+		"branch": "styhead/rz-cmn-support-v2h-rdk",
 		"tag": "",
 		"commit": "",
 		"patches": [],


### PR DESCRIPTION
- Build scripts support to build core-image-minimal for RZV2H-RDK