### PR TITLE
rz-cmn: ubuntu: update Ubuntu base rootfs to 24.04.3

### DIFF
--- a/rz-cmn-srp/ubuntu/config.ini
+++ b/rz-cmn-srp/ubuntu/config.ini
@@ -51,7 +51,7 @@ ROOTFS_INTERNAL_FREE_SPACE_MB=1000
 #UBUNTU_BASE_FILE_NAME="ubuntu-base-22.04-base-arm64.tar.gz"
 #UBUNTU_BASE_LINK="https://cdimage.ubuntu.com/ubuntu-base/releases/22.04/release/$UBUNTU_BASE_FILE_NAME"
 
-UBUNTU_BASE_FILE_NAME="ubuntu-base-24.04.2-base-arm64.tar.gz"
+UBUNTU_BASE_FILE_NAME="ubuntu-base-24.04.3-base-arm64.tar.gz"
 UBUNTU_BASE_LINK="https://cdimage.ubuntu.com/ubuntu-base/releases/24.04/release/$UBUNTU_BASE_FILE_NAME"
 
 # Define output rootfs file name


### PR DESCRIPTION
Upstream has removed 24.04.2 from cdimage, so update UBUNTU_BASE_FILE_NAME to use 24.04.3 instead.