### PR TITLE
rz-cmn: correct build parameter precedence and defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ $ tree -L 3
     ├── jq-linux-amd64          <---- Local copy of `jq` for JSON processing
     ├── patches/                <---- Patch sets organized by target layer
     │   ├── meta-summit-radio/
-    │   └── meta-rz-features/
+    │   ├── meta-rz-features/
+    │   └── poky/
     ├── README.md               <---- Detailed guide for Ubuntu and Yocto builds.
     ├── rz_builder.sh        <---- Unified entry point for both Yocto and Ubuntu builds
     ├── site.conf               /* (optional) */

--- a/rz-cmn-srp/README.md
+++ b/rz-cmn-srp/README.md
@@ -62,7 +62,9 @@ $ tree -L 3
 ## Image Categories
 
 The `config.json` file contains the list of available build options such as machine types and image options categorized by build system and image groups meant for the build script to verify against.
+
 The user can use this config in three ways:
+
     1. Read it to check available options.
     2. Alter the lists and values to control the build with changed defaults
     3. Alter the lists to build new user images without changing any build code. 

--- a/rz-cmn-srp/README.md
+++ b/rz-cmn-srp/README.md
@@ -17,9 +17,11 @@ $ tree -L 3
 ├── patches
 │   ├── meta-rz-features
 │   │   └── 0001-support-codec-for-linux-6.10-and-yocto-styhead.patch
-│   └── meta-summit-radio
-│       ├── 0001-rz-sbc-meta-summit-radio-Support-build-in-yocto-styh.patch
-│       └── 0002-rz-sbc-summit-radio-support-eSDK-build.patch
+│   ├── meta-summit-radio
+│   │   ├── 0001-rz-sbc-meta-summit-radio-Support-build-in-yocto-styh.patch
+│   │   └── 0002-rz-sbc-summit-radio-support-eSDK-build.patch
+│   └── poky
+│       └── 0001-uboot-config-Fix-devtool-modify.patch
 ├── README.md
 ├── rz_builder.sh
 └── ubuntu
@@ -174,6 +176,8 @@ renesas@builder-pc:~/renesas/rz-cmn-srp/yocto_rzcmn_board/build/tmp/deploy/image
 │   │       ├── git_patch.json
 │   │       ├── jq-linux-amd64
 │   │       ├── patches
+│   │       │   ├── poky
+│   │       │   │   └── 0001-uboot-config-Fix-devtool-modify.patch
 │   │       │   ├── meta-rz-features
 │   │       │   │   └── 0001-support-codec-for-linux-6.10-and-yocto-styhead.patch
 │   │       │   └── meta-summit-radio

--- a/rz-cmn-srp/git_patch.json
+++ b/rz-cmn-srp/git_patch.json
@@ -4,7 +4,7 @@
 		"branch": "styhead",
 		"tag": "",
 		"commit": "",
-		"patches": [],
+		"patches": ["patches/poky/0001-uboot-config-Fix-devtool-modify.patch"],
 		"type": "git",
 		"enable": "true"
 	},

--- a/rz-cmn-srp/patches/poky/0001-uboot-config-Fix-devtool-modify.patch
+++ b/rz-cmn-srp/patches/poky/0001-uboot-config-Fix-devtool-modify.patch
@@ -1,0 +1,76 @@
+From 371ecef31872a611f34b2541a50ceed0c3ce06af Mon Sep 17 00:00:00 2001
+From: Tom Hochstein <tom.hochstein@oss.nxp.com>
+Date: Wed, 5 Feb 2025 16:18:55 -0600
+Subject: [PATCH] uboot-config: Fix devtool modify
+
+Fix a problem with `devtool modify` as suggested by Marcus Flyckt on
+the mailing list:
+```
+    I encountered an issue with `do_config` when using `devtool modify`
+    on `u-boot-imx`.
+
+    ```
+    [...]
+    | cp: cannot stat '[...]/u-boot-imx/2024.04/build/imx8mp_wl400s_defconfig/.config': No such file or directory
+    | WARNING: exit code 1 from a shell command.
+    ERROR: Task ([...]/sources/poky/../meta-freescale/recipes-bsp/u-boot/u-boot-imx_2024.04.bb:do_configure) failed with exit code '1'
+    NOTE: Tasks Summary: Attempted 963 tasks of which 962 didn't need to be rerun and 1 failed.
+    Summary: 1 task failed:
+      [...]/sources/poky/../meta-freescale/recipes-bsp/u-boot/u-boot-imx_2024.04.bb:do_configure
+    Summary: There was 1 ERROR message, returning a non-zero exit code
+    ```
+
+    The issue seems to originate from the following lines in
+    `workspace/appends/u-boot-imx_2024.04.bbappend`:
+
+    ```
+    do_configure:append() {
+        if [ ${@oe.types.boolean(d.getVar("KCONFIG_CONFIG_ENABLE_MENUCONFIG"))} = True ]; then
+            cp ${KCONFIG_CONFIG_ROOTDIR}/.config ${S}/.config.baseline
+            ln -sfT ${KCONFIG_CONFIG_ROOTDIR}/.config ${S}/.config.new
+        fi
+    }
+    ```
+
+    For some reason `KCONFIG_CONFIG_ROOTDIR` does not point to the
+    correct directory. It gets its value in `uboot-config.bbclass`:
+
+    ```
+    if len(ubootconfig) == 1:
+                    d.setVar('KCONFIG_CONFIG_ROOTDIR', os.path.join(d.getVar("B"), d.getVar("UBOOT_MACHINE").strip()))
+    ```
+
+    So the main issue is that B gets expanded in this expression, and
+    then later B gets changed by `externalsrc.bbclass`.
+    `d.getVar("B", False)` does not solve the issue, however the
+    proposed change does.
+```
+- https://lists.yoctoproject.org/g/yocto/topic/109254298#msg64152]
+
+Fixes [YOCTO #15603]
+
+Suggested-by: Marcus Flyckt <marcus.flyckt@gmail.com>
+(From OE-Core rev: 57b21065a25100c31515b32fd7c77bde3355d684)
+
+Signed-off-by: Tom Hochstein <tom.hochstein@oss.nxp.com>
+Signed-off-by: Richard Purdie <richard.purdie@linuxfoundation.org>
+---
+ meta/classes-recipe/uboot-config.bbclass | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/meta/classes-recipe/uboot-config.bbclass b/meta/classes-recipe/uboot-config.bbclass
+index bf21961977..74992182c3 100644
+--- a/meta/classes-recipe/uboot-config.bbclass
++++ b/meta/classes-recipe/uboot-config.bbclass
+@@ -144,7 +144,7 @@ python () {
+             # Ensure the uboot specific menuconfig settings do not leak into other recipes
+             if 'u-boot' in recipename:
+                 if len(ubootconfig) == 1:
+-                    d.setVar('KCONFIG_CONFIG_ROOTDIR', os.path.join(d.getVar("B"), d.getVar("UBOOT_MACHINE").strip()))
++                    d.setVar('KCONFIG_CONFIG_ROOTDIR', os.path.join("${B}", d.getVar("UBOOT_MACHINE").strip()))
+                 else:
+                     # Disable menuconfig for multiple configs
+                     d.setVar('KCONFIG_CONFIG_ENABLE_MENUCONFIG', "false")
+-- 
+2.43.0
+

--- a/rz-cmn-srp/rz_builder.sh
+++ b/rz-cmn-srp/rz_builder.sh
@@ -39,10 +39,10 @@ DEFAULT_MACHINE=$("${JQ}" -r '.defaults.machine' "$CONFIG_JSON")
 DEFAULT_IMG=$("${JQ}" -r '.defaults.image' "$CONFIG_JSON")
 
 # Default image is core-image-weston
-IMAGE="${DEFAULT_IMG:-core-image-weston}"
+IMAGE="${IMAGE:-${DEFAULT_IMG:-core-image-weston}}"
 
 # Default machine is rz-cmn
-MACHINE="${DEFAULT_MACHINE:-rz-cmn}"
+MACHINE="${MACHINE:-${DEFAULT_MACHINE:-rz-cmn}}"
 
 export IMAGE MACHINE
 # ------------------------------------------------------------------------------
@@ -719,7 +719,7 @@ setup() {
 	echo "Target contents in ${RZ_TARGET_DIR}:"
 	(ls "${RZ_TARGET_DIR}")
 	echo ""
-	echo "Finished preparing the rz yocto build source repository for RZ SBC board"
+	echo "Finished preparing the Yocto build source repository for the RZ Common System."
 	echo "========================================================================="
 }
 
@@ -1005,7 +1005,7 @@ output() {
 	echo "The output located at: $OUTPUT"
 	ls -la $OUTPUT
 	echo
-	echo "Finished collecting the rz yocto output for RZ SBC board"
+	echo "Finished collecting Yocto build output for the RZ Common System"
 	echo "======================================================================"
 }
 


### PR DESCRIPTION
Prefer CLI env vars, then config.json defaults, then hardcoded fallbacks.