### PR TITLE
rz-cmn: deploy ubuntu build scripts when using build-sdk

### DIFF
--- a/rz-cmn-srp/rz_builder.sh
+++ b/rz-cmn-srp/rz_builder.sh
@@ -805,6 +805,7 @@ build_sdk() {
 	esac
 
 	deploy_build_assets
+	deploy_ubuntu_build_assets
 	#output
 }
 


### PR DESCRIPTION
`build-sdk` currently deploys only Yocto-related build scripts. Include the Ubuntu build scripts as well so SDK users have both Yocto and Ubuntu helpers available after a build.