### PR TITLE
rz-cmn: move layer/image/GPU config to layer_override.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ $ tree -L 3
 ├── README.md                   <---- Top-level documentation (this file)
 └── rz-cmn-srp/                 <---- Main build logic and scripts
     ├── config.json             <---- Build config options. Lists availabele options for build script to go over.
+    ├── layer_override.json     <---- Customize BBLAYERS, image packages, and GPU mode before build.
     ├── files_to_add/           <---- Additional files to be copied into build environment.
     │   └── meta-rz-features/
     ├── git_patch.json          <---- JSON definitions for managing repositories and patches

--- a/rz-cmn-srp/README.md
+++ b/rz-cmn-srp/README.md
@@ -8,6 +8,7 @@ This directory contains automated build scripts and resources for performing Yoc
 $ tree -L 3
 .
 ├── config.json
+├── layer_override.json
 ├── files_to_add
 │   └── meta-rz-features
 │       └── meta-rz-codecs
@@ -50,6 +51,7 @@ $ tree -L 3
 |----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | git_patch.json        | Contains json keys and repository configuration such as: url, branch, tag, commit, repo type and patch paths to apply.                                          |
 | config.json           | Contains the config options including available build image options grouped by build type, including Yocto images, Ubuntu images, and static image collections (all-yocto-images, all-ubuntu-images, all-supported-images).|
+| layer_override.json   | Pre-build customization file: add/remove meta-layers in BBLAYERS, append/exclude image packages, and select GPU mode (none/panfrost/mali). Applied before BitBake runs. |
 | jq-linux-amd64        | JSON querry oss binary to perform reads of git_patch.json from shell script.                                                                                    |
 | patches/              | Folder containing patches. This should ideally be organized into sub directories named after the json key.                                                      |
 | files_to_add/              | A folder containing additional files that need to be added to the meta layer. These files are specified in the `add_files` field of `git_patch.json`, which defines their source locations and target destinations. For example: <br><br>**meta-rz-features/** <br>• 0001-rzg2l-sbc-Bring-compat_alloc_user_space-back.patch<br>• 0004-rzg2l-sbc-Get-interrupt-number.patch|
@@ -100,7 +102,7 @@ It also lists the available `machine` types
 
 ### Layers and Graphics Customization
 
-The `features` section in `config.json` applies customization before BitBake runs. It adds or removes entries of meta-layer in BBLAYERS, adjusts image package lists, and sets GPU configuration.
+The `features` section in `layer_override.json` applies customization before BitBake runs. It adds or removes entries of meta-layer in BBLAYERS, adjusts image package lists, and sets GPU configuration.
 
 - `layers`: Supports `add`/`remove` entries of meta-layer in BBLAYERS, either a specific layer path (has `conf/layer.conf`) or a folder of layers (adds/removes all valid sub-layers under it).
 - `libraries`: Control image packages. `add` appends packages, `remove` excludes packages (and marks as bad recommendations).
@@ -165,7 +167,7 @@ DRP-AI (Dynamically Reconfigurable Processor + AI-MAC) is an on-chip accelerator
 DRP-AI is enabled by default through the DRP-AI-related repositories/layers being included in the build configuration:
 
 - `git_patch.json`: DRP-AI repositories are enabled (fetched during setup).
-- `config.json`: DRP-AI layers are listed under features.layers.add so they are included in the build layer stack.
+- `layer_override.json`: DRP-AI layers are listed under features.layers.add so they are included in the build layer stack.
 
 In `git_patch.json`:
 
@@ -190,7 +192,7 @@ In `git_patch.json`:
 	}
 ```
 
-In `config.json`:
+In `layer_override.json`:
 
 ```json
 	"features": {
@@ -210,11 +212,11 @@ In `config.json`:
 	}
 ```
 
-- **To disable DRP AI:** ensure the DRP-AI-related layers are not present in BBLAYERS. In this build system, that is done by updating config.json under features.layers to:
+- **To disable DRP AI:** ensure the DRP-AI-related layers are not present in BBLAYERS. In this build system, that is done by updating `layer_override.json` under features.layers to:
 	- remove the DRP-AI layer paths from add, and
 	- list the same paths under remove so they are actively excluded from the layer stack.
 
-In `config.json`:
+In `layer_override.json`:
 
 ```diff
 	"features": {
@@ -281,6 +283,7 @@ renesas@builder-pc:~/renesas/rz-cmn-srp/yocto_rzcmn_board/build/tmp/deploy/image
 │   ├── src
 │   │   └── rz-cmn-srp
 │   │       ├── config.json
+│   │       ├── layer_override.json
 │   │       ├── files_to_add
 │   │       │   └── meta-rz-features
 │   │       │       ├── 0001-rzg2l-sbc-Bring-compat_alloc_user_space-back.patch

--- a/rz-cmn-srp/config.json
+++ b/rz-cmn-srp/config.json
@@ -35,21 +35,5 @@
 	"defaults": {
 		"machine": "rz-cmn",
 		"image": "core-image-weston"
-	},
-	"features": {
-        "layers": {
-            "add": [
-                "meta-rz-features/meta-rz-codecs",
-                "rzv2h_opencv_accelerator/meta-rz-features/meta-rz-opencva",
-                "rzv_drp-ai_driver/meta-rz-features/meta-rz-drpai"
-            ],
-            "remove": [
-            ]
-        },
-		"libraries": {
-			"add": [],
-			"remove": []
-		},
-		"gpu": "panfrost"
 	}
 }

--- a/rz-cmn-srp/layer_override.json
+++ b/rz-cmn-srp/layer_override.json
@@ -1,0 +1,18 @@
+{
+	"features": {
+		"layers": {
+			"add": [
+				"meta-rz-features/meta-rz-codecs",
+				"rzv2h_opencv_accelerator/meta-rz-features/meta-rz-opencva",
+				"rzv_drp-ai_driver/meta-rz-features/meta-rz-drpai"
+			],
+			"remove": [
+			]
+		},
+		"libraries": {
+			"add": [],
+			"remove": []
+		},
+		"gpu": "panfrost"
+	}
+}

--- a/rz-cmn-srp/rz_builder.sh
+++ b/rz-cmn-srp/rz_builder.sh
@@ -34,6 +34,7 @@ TOP_DIR=$(pwd)
 JQ="${TOP_DIR}/jq-linux-amd64"
 PATCH_FILE="${TOP_DIR}/git_patch.json"
 CONFIG_JSON="${TOP_DIR}/config.json"
+LAYER_OVERRIDE_JSON="${TOP_DIR}/layer_override.json"
 
 DEFAULT_MACHINE=$("${JQ}" -r '.defaults.machine' "$CONFIG_JSON")
 DEFAULT_IMG=$("${JQ}" -r '.defaults.image' "$CONFIG_JSON")
@@ -665,13 +666,14 @@ unpack_codec() {
 	rm -fr ${zip_dir}
 }
 
-# Set or replace a variable in local.conf
+# Set or replace a variable in auto.conf
 conf_set_variable() {
 	local var="$1"
 	local val="$2"
 	local lconf="${AUTO_CONF_FILE}"
 
-	[ -f "$lconf" ] || { log_error "Missing ${lconf}"; exit 1; }
+	[ -f "$lconf" ] || touch "$lconf"
+
 	# Remove any existing lines that set the var
 	sed -i "/^${var}[[:space:]]*=.*/d" "${lconf}"
 	echo "${var} = \"${val}\"" >> "${lconf}"
@@ -682,7 +684,7 @@ conf_clean_libraries() {
 	local lconf="${AUTO_CONF_FILE}"
 
 	[ -f "$lconf" ] || { log_error "Missing ${lconf}"; exit 1; }
-	# Refresh previous lines in the local.conf
+	# Refresh previous lines in the auto.conf
 	sed -i '\|^IMAGE_INSTALL:append = " \${USER_IMAGE_ADD}"$|d' "${lconf}"
 	sed -i '\|^PACKAGE_EXCLUDE += " \${USER_PACKAGE_EXCLUDE}"$|d' "${lconf}"
 	sed -i '\|^BAD_RECOMMENDATIONS += " \${USER_PACKAGE_EXCLUDE}"$|d' "${lconf}"
@@ -773,12 +775,12 @@ apply_add_remove_layers() {
 	# drop codec layer entry and manage via bitbake-layers instead
 	sed -i '/meta-rz-features\/meta-rz-codecs/d' "${RZ_TARGET_DIR}/build/conf/bblayers.conf"
 
-	layers_add=$(${JQ} -r '.features.layers.add[]? // empty' "${CONFIG_JSON}" | awk 'NF')
+	layers_add=$(${JQ} -r '.features.layers.add[]? // empty' "${LAYER_OVERRIDE_JSON}" | awk 'NF')
 	for layer in ${layers_add}; do
 		add_layer "${layer}"
 	done
 
-	layers_remove=$(${JQ} -r '.features.layers.remove[]? // empty' "${CONFIG_JSON}" | awk 'NF')
+	layers_remove=$(${JQ} -r '.features.layers.remove[]? // empty' "${LAYER_OVERRIDE_JSON}" | awk 'NF')
 	for layer in ${layers_remove}; do
 		remove_layer "${layer}"
 	done
@@ -791,11 +793,11 @@ apply_add_remove_layers() {
 	fi
 }
 
-# Parse libraries from config.json to handle add/remove
+# Parse libraries from layer_override.json to handle add/remove
 apply_libraries() {
 	local ADD_LIBS REMOVE_LIBS
-	ADD_LIBS=$(${JQ} -r '.features.libraries?.add[]? // empty' "${CONFIG_JSON}" | tr '\n' ' ')
-	REMOVE_LIBS=$(${JQ} -r '.features.libraries?.remove[]? // empty' "${CONFIG_JSON}" | tr '\n' ' ')
+	ADD_LIBS=$(${JQ} -r '.features.libraries?.add[]? // empty' "${LAYER_OVERRIDE_JSON}" | tr '\n' ' ')
+	REMOVE_LIBS=$(${JQ} -r '.features.libraries?.remove[]? // empty' "${LAYER_OVERRIDE_JSON}" | tr '\n' ' ')
 
 	# Refresh the template
 	conf_clean_libraries
@@ -811,7 +813,7 @@ apply_libraries() {
 
 apply_gpu_feature() {
 	local GPU_MODE
-	GPU_MODE=$(${JQ} -r '.features.gpu // "none"' "${CONFIG_JSON}")
+	GPU_MODE=$(${JQ} -r '.features.gpu // "none"' "${LAYER_OVERRIDE_JSON}")
 	log_info "GPU mode: ${GPU_MODE}"
 
 	# Control RZ_FEATURE_PANFROST in meta-renesas
@@ -864,7 +866,7 @@ setup_conf(){
 		echo "This build is based on release tag:$revision_value. Target image: ${IMAGE}"
 	fi
 
-	AUTO_CONF_FILE="${RZ_TARGET_DIR}/build/conf/local.conf"
+	AUTO_CONF_FILE="${RZ_TARGET_DIR}/build/conf/auto.conf"
 	export AUTO_CONF_FILE
 	
 	apply_add_remove_layers
@@ -1133,6 +1135,7 @@ deploy_build_assets() {
 	# Copy build assets to the src directory
 	cp "${PATCH_FILE}" "${target_dir}"
 	cp "${CONFIG_JSON}" "${target_dir}"
+	cp "${LAYER_OVERRIDE_JSON}" "${target_dir}"
 	cp "${JQ}" "${target_dir}"
 	cp -r "${TOP_DIR}/patches" "${target_dir}"
 	cp -r "${TOP_DIR}/files_to_add" "${target_dir}"
@@ -1200,11 +1203,14 @@ if ! command -v ${JQ} >/dev/null 2>&1; then
 	exit 1
 fi
 
-# Check if the config.json file exists
-if [ ! -f "${CONFIG_JSON}" ]; then
-  echo "JSON file not found: ${CONFIG_JSON}"
-  exit 1
-fi
+# Validate JSON files early
+for f in "${CONFIG_JSON}" "${LAYER_OVERRIDE_JSON}" "${PATCH_FILE}"; do
+    if ! ${JQ} empty "$f" 2>/dev/null; then
+        log_error "Invalid JSON in: $f"
+        ${JQ} . "$f"   # show jq's detailed error
+        exit 1
+    fi
+done
 
 ${JQ} -r '.images | del(.static) | .. | arrays | .[]' "${CONFIG_JSON}" > /tmp/build-images.lst
 ${JQ} -r '.images.static[][0]' "${CONFIG_JSON}" >> /tmp/build-images.lst


### PR DESCRIPTION
Changes include:
- Split features.{layers,libraries,gpu} from config.json into layer_override.json
- Write customizations to build/conf/auto.conf instead of local.conf
- Validate all JSON inputs early via jq with detailed errors
- Copy layer_override.json into deployed src
- Update READMEs accordingly